### PR TITLE
SDK allow developer to specify from Name associated with the sender

### DIFF
--- a/dapp/README.md
+++ b/dapp/README.md
@@ -21,6 +21,7 @@ fill in the environment variables:
 - **IEXEC_REQUESTER_SECRET_2**: The content of the email to be sent to the email address retrieved from the data.zip file.
 - **IEXEC_REQUESTER_SECRET_3** _(optional)_: A JSON string with the following keys:
   - **contentType** _(optional)_: the email content type `"text/plain"` or `"text/html"`
+  - **senderName** _(optional)_: the email sender name, it must be between 3 and 20 characters long. It will be displayed as `"<senderName> via Web3mail"` in the `"From"` email header.
 
 ### Install dependencies
 

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -31,3 +31,6 @@ const validContentTypes = ['text/plain', 'text/html'];
 
 export const contentTypeSchema = () =>
   string().oneOf(validContentTypes, 'Invalid contentType').optional();
+
+// Minimum of 3 characters and max of 20 to avoid sender being flagged as spam
+export const senderNameSchema = () => string().min(3).max(20).optional();

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -33,4 +33,4 @@ export const contentTypeSchema = () =>
   string().oneOf(validContentTypes, 'Invalid contentType').optional();
 
 // Minimum of 3 characters and max of 20 to avoid sender being flagged as spam
-export const senderNameSchema = () => string().min(3).max(20).optional();
+export const senderNameSchema = () => string().trim().min(3).max(20).optional();

--- a/src/web3mail/sendEmail.ts
+++ b/src/web3mail/sendEmail.ts
@@ -145,7 +145,7 @@ export const sendEmail = async ({
     await iexec.secrets.pushRequesterSecret(emailContentId, vEmailContent);
     await iexec.secrets.pushRequesterSecret(
       optionsId,
-      JSON.stringify({ contentType: vContentType })
+      JSON.stringify({ contentType: vContentType, senderName: vSenderName })
     );
     // Create and sign request order
     const requestorderToSign = await iexec.order.createRequestorder({

--- a/src/web3mail/sendEmail.ts
+++ b/src/web3mail/sendEmail.ts
@@ -13,6 +13,7 @@ import {
   contentTypeSchema,
   emailContentSchema,
   emailSubjectSchema,
+  senderNameSchema,
   throwIfMissing,
 } from '../utils/validators.js';
 import {
@@ -28,6 +29,7 @@ export const sendEmail = async ({
   emailSubject,
   emailContent,
   contentType = DEFAULT_CONTENT_TYPE,
+  senderName,
   protectedData,
 }: IExecConsumer &
   SubgraphConsumer &
@@ -45,11 +47,13 @@ export const sendEmail = async ({
       .required()
       .label('emailContent')
       .validateSync(emailContent);
-
     const vContentType = contentTypeSchema()
       .required()
       .label('contentType')
       .validateSync(contentType);
+    const vSenderName = senderNameSchema()
+      .label('senderName')
+      .validateSync(senderName);
 
     // Check protected data validity through subgraph
     const isValidProtectedData = await checkProtectedDataValidity(

--- a/src/web3mail/types.ts
+++ b/src/web3mail/types.ts
@@ -21,6 +21,7 @@ export type SendEmailParams = {
   emailContent: string;
   protectedData: Address;
   contentType?: string;
+  senderName?: string;
 };
 
 export type SendEmailResponse = {

--- a/tests/e2e/sendEmail.test.ts
+++ b/tests/e2e/sendEmail.test.ts
@@ -117,4 +117,49 @@ describe('web3mail.sendEmail()', () => {
     },
     3 * MAX_EXPECTED_BLOCKTIME
   );
+  it(
+    'should successfully send email with a valid senderName',
+    async () => {
+      const params = {
+        emailSubject: 'e2e mail object for test',
+        emailContent: 'e2e mail content for test',
+        protectedData: validProtectedData.address,
+        senderName: 'Product Team'
+      };
+
+      const sendEmailResponse = await web3mail.sendEmail(params);
+      expect(sendEmailResponse.taskId).toBeDefined();
+    },
+    3 * MAX_EXPECTED_BLOCKTIME
+  );
+  it(
+    'should fail to send email with an invalid (too short) senderName',
+    async () => {
+      const params = {
+        emailSubject: 'e2e mail object for test',
+        emailContent: 'e2e mail content for test',
+        protectedData: validProtectedData.address,
+        senderName: 'AB'
+      };
+      await expect(web3mail.sendEmail(params)).rejects.toThrow(
+        'senderName must be at least 3 characters'
+      );
+    },
+    3 * MAX_EXPECTED_BLOCKTIME
+  );
+  it(
+    'should fail to send email with an invalid (too long) senderName',
+    async () => {
+      const params = {
+        emailSubject: 'e2e mail object for test',
+        emailContent: 'e2e mail content for test',
+        protectedData: validProtectedData.address,
+        senderName: 'A very long sender name'
+      };
+      await expect(web3mail.sendEmail(params)).rejects.toThrow(
+        'senderName must be at most 20 characters'
+      );
+    },
+    3 * MAX_EXPECTED_BLOCKTIME
+  );
 });

--- a/tests/unit/utils/validators.test.ts
+++ b/tests/unit/utils/validators.test.ts
@@ -4,6 +4,7 @@ import {
   addressOrEnsSchema,
   emailSubjectSchema,
   emailContentSchema,
+  senderNameSchema,
 } from '../../../dist/utils/validators';
 import { getRandomAddress, getRequiredFieldMessage } from '../../test-utils';
 
@@ -128,6 +129,30 @@ Even the all-powerful Pointing has no control about the blind texts it is an alm
       expect(() => emailContentSchema().validateSync(CONTENT + '.')).toThrow(
         'this must be at most 4096 characters'
       );
+    });
+  });
+});
+
+describe('senderNameSchema()', () => {
+  describe('validateSync()', () => {
+    it('pass with valid senderName', () => {
+      const senderName = 'Product Team';
+      const res = senderNameSchema().validateSync(senderName);
+      expect(res).toBe(senderName);
+    });
+    it('blocks too short senderName', () => {
+      expect(() =>
+      senderNameSchema().validateSync(
+          'AB'
+        )
+      ).toThrow('this must be at least 3 characters');
+    });
+    it('blocks too long senderName', () => {
+      expect(() =>
+      senderNameSchema().validateSync(
+          'A very long sender name'
+        )
+      ).toThrow('this must be at most 20 characters');
     });
   });
 });

--- a/tests/unit/utils/validators.test.ts
+++ b/tests/unit/utils/validators.test.ts
@@ -147,6 +147,13 @@ describe('senderNameSchema()', () => {
         )
       ).toThrow('this must be at least 3 characters');
     });
+    it('blocks empty characters as senderName', () => {
+      expect(() =>
+      senderNameSchema().validateSync(
+          '   '
+        )
+      ).toThrow('this must be at least 3 characters');
+    });
     it('blocks too long senderName', () => {
       expect(() =>
       senderNameSchema().validateSync(


### PR DESCRIPTION
Allows the SDK to pass a parameter "senderName" to the sendEmail method. 