### PR TITLE
Feature/whitelist integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -367,7 +367,10 @@ steps:
     image: node:18
     pull: always
     commands:
-      - cd deployment-dapp
+      - npm ci
+      - cd node_modules/whitelist-smart-contract
+      - npm install --save-dev ts-node
+      - cd ../../deployment-dapp
       - npm ci
 
   - name: deploy dapp contract
@@ -416,6 +419,44 @@ steps:
     commands:
       - cd deployment-dapp
       - npm run publish-sell-order
+      
+  - name: add resource to whitelist dev
+    image: node:18.12.1
+    environment:
+      WALLET_PRIVATE_KEY:
+        from_secret: web3mail-dapp-owner-dev-privatekey
+      CONTRACT_ADDRESS:
+        from_secret: web3mail-whitelist-dev-address
+    commands:
+      - cd node_modules/whitelist-smart-contract
+      - cat ../../deployment-dapp/.app-address
+      - ls ../../deployment-dapp
+      - ls ../../deployment-dapp/src
+      - export ADDRESS_TO_ADD=$(cat ../../deployment-dapp/.app-address) && npm run addResourceToWhitelist
+    when:
+      target:
+        - dapp-dev
+      branch:
+        - develop
+
+  - name: add resource to whitelist prod
+    image: node:18.12.1
+    environment:
+      WALLET_PRIVATE_KEY:
+        from_secret: web3mail-dapp-owner-prod-privatekey
+      CONTRACT_ADDRESS:
+        from_secret: web3mail-whitelist-prod-address
+    commands:
+      - cd node_modules/whitelist-smart-contract
+      - cat ../../deployment-dapp/.app-address
+      - ls ../../deployment-dapp
+      - ls ../../deployment-dapp/src
+      - export ADDRESS_TO_ADD=$(cat ../../deployment-dapp/.app-address) && npm run addResourceToWhitelist
+    when:
+      target:
+        - dapp-prod
+      branch:
+        - main
 
   - name: configure ENS
     image: node:18
@@ -578,7 +619,7 @@ steps:
       - cd node_modules/whitelist-smart-contract
       - npm install --save-dev ts-node
 
-  - name: add ressource to whitelist dev
+  - name: add resource to whitelist dev
     image: node:18.12.1
     params:
       - ADDRESS_TO_ADD

--- a/.drone.yml
+++ b/.drone.yml
@@ -419,7 +419,7 @@ steps:
     commands:
       - cd deployment-dapp
       - npm run publish-sell-order
-      
+
   - name: add resource to whitelist dev
     image: node:18.12.1
     environment:
@@ -586,7 +586,7 @@ steps:
     commands:
       - cd deployment-dapp
       - npm run push-dapp-secret
-
+---
 # pipeline to add ressource to whitelist smart contract
 kind: pipeline
 type: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -585,7 +585,7 @@ steps:
       - ADDRESS_TO_ADD
     environment:
       WALLET_PRIVATE_KEY:
-        from_secret: deployer-dev-privatekey
+        from_secret: web3mail-dapp-owner-dev-privatekey
     commands:
       - cd node_modules/whitelist-smart-contract
       - npm run addRessourceToWhitelist
@@ -602,7 +602,7 @@ steps:
       - ADDRESS_TO_ADD
     environment:
       WALLET_PRIVATE_KEY:
-        from_secret: deployer-prod-privatekey
+        from_secret: web3mail-dapp-owner-prod-privatekey
     commands:
       - cd node_modules/whitelist-smart-contract
       - npm run addRessourceToWhitelist
@@ -645,7 +645,7 @@ steps:
       - ADDRESS_TO_REMOVE
     environment:
       WALLET_PRIVATE_KEY:
-        from_secret: deployer-dev-privatekey
+        from_secret: web3mail-dapp-owner-dev-privatekey
     commands:
       - cd node_modules/whitelist-smart-contract
       - npm run removeRessourceFromWhitelist
@@ -662,7 +662,7 @@ steps:
       - ADDRESS_TO_REMOVE
     environment:
       WALLET_PRIVATE_KEY:
-        from_secret: deployer-prod-privatekey
+        from_secret: web3mail-dapp-owner-prod-privatekey
     commands:
       - cd node_modules/whitelist-smart-contract
       - npm run removeRessourceFromWhitelist
@@ -704,7 +704,7 @@ steps:
       - NEW_OWNER_ADDRESS
     environment:
       WALLET_PRIVATE_KEY:
-        from_secret: deployer-dev-privatekey
+        from_secret: web3mail-dapp-owner-dev-privatekey
     commands:
       - cd node_modules/whitelist-contract
       - npm run transferOwnership
@@ -720,7 +720,7 @@ steps:
       - NEW_OWNER_ADDRESS
     environment:
       WALLET_PRIVATE_KEY:
-        from_secret: deployer-prod-privatekey
+        from_secret: web3mail-dapp-owner-prod-privatekey
     commands:
       - cd node_modules/whitelist-smart-contract
       - npm run transferOwnership

--- a/.drone.yml
+++ b/.drone.yml
@@ -561,8 +561,8 @@ trigger:
   event:
     - promote
   target:
-    - add-ressource-to-whitelist-dev
-    - add-ressource-to-whitelist-prod
+    - add-resource-to-whitelist-dev
+    - add-resource-to-whitelist-prod
   branch:
     - develop
     - main
@@ -589,14 +589,14 @@ steps:
         from_secret: web3mail-whitelist-dev-address
     commands:
       - cd node_modules/whitelist-smart-contract
-      - npm run addRessourceToWhitelist
+      - npm run addResourceToWhitelist
     when:
       target:
-        - add-ressource-to-whitelist-dev
+        - add-resource-to-whitelist-dev
       branch:
         - develop
 
-  - name: add ressource to whitelist prod
+  - name: add resource to whitelist prod
     image: node:18.12.1
     params:
       - ADDRESS_TO_ADD
@@ -607,24 +607,24 @@ steps:
         from_secret: web3mail-whitelist-prod-address
     commands:
       - cd node_modules/whitelist-smart-contract
-      - npm run addRessourceToWhitelist
+      - npm run addResourceToWhitelist
     when:
       target:
-        - add-ressource-to-whitelist-prod
+        - add-resource-to-whitelist-prod
       branch:
         - main
 ---
 # pipeline to remove ressource from whitelist smart contract
 kind: pipeline
 type: docker
-name: remove-ressource-from-whitelist
+name: remove-resource-from-whitelist
 
 trigger:
   event:
     - promote
   target:
-    - remove-ressource-from-whitelist-dev
-    - remove-ressource-from-whitelist-prod
+    - remove-resource-from-whitelist-dev
+    - remove-resource-from-whitelist-prod
   branch:
     - develop
     - main
@@ -651,14 +651,14 @@ steps:
         from_secret: web3mail-whitelist-dev-address
     commands:
       - cd node_modules/whitelist-smart-contract
-      - npm run removeRessourceFromWhitelist
+      - npm run removeResourceFromWhitelist
     when:
       target:
-        - remove-ressource-from-whitelist-dev
+        - remove-resource-from-whitelist-dev
       branch:
         - develop
 
-  - name: remove ressource from whitelist prod
+  - name: remove resource from whitelist prod
     image: node:18.12.1
     params:
       - ADDRESS_TO_REMOVE
@@ -669,10 +669,10 @@ steps:
         from_secret: web3mail-whitelist-prod-address
     commands:
       - cd node_modules/whitelist-smart-contract
-      - npm run removeRessourceFromWhitelist
+      - npm run removeResourceFromWhitelist
     when:
       target:
-        - remove-ressource-from-whitelist-prod
+        - remove-resource-from-whitelist-prod
       branch:
         - main
 ---

--- a/.drone.yml
+++ b/.drone.yml
@@ -343,7 +343,7 @@ trigger:
 
 steps:
   - name: get scone fingerprint (dev)
-    image: iexechub/web3mail-dapp:dev-${DRONE_COMMIT}-sconify-5.7.5-v12-production
+    image: iexechub/web3mail-dapp:dev-fe05c685bf8887fe94f4f8a8ad5826fee8b98a05-sconify-5.7.5-v12-production
     commands:
       - SCONE_HASH=1 node > deployment-dapp/.scone-fingerprint
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -343,7 +343,7 @@ trigger:
 
 steps:
   - name: get scone fingerprint (dev)
-    image: iexechub/web3mail-dapp:dev-fe05c685bf8887fe94f4f8a8ad5826fee8b98a05-sconify-5.7.5-v12-production
+    image: iexechub/web3mail-dapp:dev-${DRONE_COMMIT}-sconify-5.7.5-v12-production
     commands:
       - SCONE_HASH=1 node > deployment-dapp/.scone-fingerprint
     when:
@@ -429,9 +429,6 @@ steps:
         from_secret: web3mail-whitelist-dev-address
     commands:
       - cd node_modules/whitelist-smart-contract
-      - cat ../../deployment-dapp/.app-address
-      - ls ../../deployment-dapp
-      - ls ../../deployment-dapp/src
       - export ADDRESS_TO_ADD=$(cat ../../deployment-dapp/.app-address) && npm run addResourceToWhitelist
     when:
       target:
@@ -448,9 +445,6 @@ steps:
         from_secret: web3mail-whitelist-prod-address
     commands:
       - cd node_modules/whitelist-smart-contract
-      - cat ../../deployment-dapp/.app-address
-      - ls ../../deployment-dapp
-      - ls ../../deployment-dapp/src
       - export ADDRESS_TO_ADD=$(cat ../../deployment-dapp/.app-address) && npm run addResourceToWhitelist
     when:
       target:

--- a/.drone.yml
+++ b/.drone.yml
@@ -581,11 +581,12 @@ steps:
   - name: add ressource to whitelist dev
     image: node:18.12.1
     params:
-      - CONTRACT_ADDRESS
       - ADDRESS_TO_ADD
     environment:
       WALLET_PRIVATE_KEY:
         from_secret: web3mail-dapp-owner-dev-privatekey
+      CONTRACT_ADDRESS:
+        from_secret: web3mail-whitelist-dev-address
     commands:
       - cd node_modules/whitelist-smart-contract
       - npm run addRessourceToWhitelist
@@ -598,11 +599,12 @@ steps:
   - name: add ressource to whitelist prod
     image: node:18.12.1
     params:
-      - CONTRACT_ADDRESS
       - ADDRESS_TO_ADD
     environment:
       WALLET_PRIVATE_KEY:
         from_secret: web3mail-dapp-owner-prod-privatekey
+      CONTRACT_ADDRESS:
+        from_secret: web3mail-whitelist-prod-address
     commands:
       - cd node_modules/whitelist-smart-contract
       - npm run addRessourceToWhitelist
@@ -641,11 +643,12 @@ steps:
   - name: remove ressource from whitelist dev
     image: node:18.12.1
     params:
-      - CONTRACT_ADDRESS
       - ADDRESS_TO_REMOVE
     environment:
       WALLET_PRIVATE_KEY:
         from_secret: web3mail-dapp-owner-dev-privatekey
+      CONTRACT_ADDRESS:
+        from_secret: web3mail-whitelist-dev-address
     commands:
       - cd node_modules/whitelist-smart-contract
       - npm run removeRessourceFromWhitelist
@@ -658,11 +661,12 @@ steps:
   - name: remove ressource from whitelist prod
     image: node:18.12.1
     params:
-      - CONTRACT_ADDRESS
       - ADDRESS_TO_REMOVE
     environment:
       WALLET_PRIVATE_KEY:
         from_secret: web3mail-dapp-owner-prod-privatekey
+      CONTRACT_ADDRESS:
+        from_secret: web3mail-whitelist-prod-address
     commands:
       - cd node_modules/whitelist-smart-contract
       - npm run removeRessourceFromWhitelist
@@ -705,6 +709,8 @@ steps:
     environment:
       WALLET_PRIVATE_KEY:
         from_secret: web3mail-dapp-owner-dev-privatekey
+      CONTRACT_ADDRESS:
+        from_secret: web3mail-whitelist-dev-address
     commands:
       - cd node_modules/whitelist-contract
       - npm run transferOwnership
@@ -721,6 +727,8 @@ steps:
     environment:
       WALLET_PRIVATE_KEY:
         from_secret: web3mail-dapp-owner-prod-privatekey
+      CONTRACT_ADDRESS:
+        from_secret: web3mail-whitelist-prod-address
     commands:
       - cd node_modules/whitelist-smart-contract
       - npm run transferOwnership

--- a/deployment-dapp/src/config/config.ts
+++ b/deployment-dapp/src/config/config.ts
@@ -26,7 +26,8 @@ const dappVersion = JSON.parse(
 export const DOCKER_IMAGE_NAMESPACE = 'iexechub';
 export const DOCKER_IMAGE_REPOSITORY = 'web3mail-dapp';
 export const DOCKER_IMAGE_PROD_TAG = `${dappVersion}-sconify-${SCONIFIER_VERSION}-production`;
-export const DOCKER_IMAGE_DEV_TAG = `dev-${process.env.DRONE_COMMIT}-sconify-${SCONIFIER_VERSION}-production`;
+export const DOCKER_IMAGE_DEV_TAG =
+  'dev-fe05c685bf8887fe94f4f8a8ad5826fee8b98a05-sconify-5.7.5-v12-production'; //`dev-${process.env.DRONE_COMMIT}-sconify-${SCONIFIER_VERSION}-production`;
 
 //drone target
 export const DRONE_TARGET_DEPLOY_DEV = 'dapp-dev';

--- a/deployment-dapp/src/config/config.ts
+++ b/deployment-dapp/src/config/config.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 export const HOST = 'https://bellecour.iex.ec';
 
 //deployment parameters
-export const APP_NAME = 'web3mail-test';
+export const APP_NAME = 'web3mail';
 export const APP_TYPE = 'DOCKER';
 export const FRAMEWORK = 'scone';
 
@@ -26,8 +26,7 @@ const dappVersion = JSON.parse(
 export const DOCKER_IMAGE_NAMESPACE = 'iexechub';
 export const DOCKER_IMAGE_REPOSITORY = 'web3mail-dapp';
 export const DOCKER_IMAGE_PROD_TAG = `${dappVersion}-sconify-${SCONIFIER_VERSION}-production`;
-export const DOCKER_IMAGE_DEV_TAG =
-  'dev-fe05c685bf8887fe94f4f8a8ad5826fee8b98a05-sconify-5.7.5-v12-production'; //`dev-${process.env.DRONE_COMMIT}-sconify-${SCONIFIER_VERSION}-production`;
+export const DOCKER_IMAGE_DEV_TAG = `dev-${process.env.DRONE_COMMIT}-sconify-${SCONIFIER_VERSION}-production`;
 
 //drone target
 export const DRONE_TARGET_DEPLOY_DEV = 'dapp-dev';

--- a/deployment-dapp/src/config/config.ts
+++ b/deployment-dapp/src/config/config.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 export const HOST = 'https://bellecour.iex.ec';
 
 //deployment parameters
-export const APP_NAME = 'web3mail';
+export const APP_NAME = 'web3mail-test';
 export const APP_TYPE = 'DOCKER';
 export const FRAMEWORK = 'scone';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "ts-jest": "^29.1.0",
         "ts-loader": "^9.4.2",
         "typescript": "^4.9.5",
-        "whitelist-smart-contract": "github:iExecBlockchainComputing/whitelist-smart-contract#0.1.0"
+        "whitelist-smart-contract": "github:iExecBlockchainComputing/whitelist-smart-contract#0.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -45,13 +45,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
-      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -4182,15 +4175,6 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.8.tgz",
       "integrity": "sha512-yW/qTM4mRBBcsA9Xw9FbcImYtFPY7sgr+G/O5RDYVmxiy9a+pE5FyoFUi8JYCZY5nicj8atrr1pcfPiYpeNGOA=="
     },
-    "node_modules/@types/chai-as-promised": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.6.tgz",
-      "integrity": "sha512-cQLhk8fFarRVZAXUQV1xEnZgMoPxqKojBvRkqPCKPQCzEhpbbSKl1Uu75kDng7k5Ln6LQLUmNBjLlFthCgm1NA==",
-      "dev": true,
-      "dependencies": {
-        "@types/chai": "*"
-      }
-    },
     "node_modules/@types/eslint": {
       "version": "8.44.4",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.4.tgz",
@@ -5814,18 +5798,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/chai-as-promised": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
-      "dev": true,
-      "dependencies": {
-        "check-error": "^1.0.2"
-      },
-      "peerDependencies": {
-        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chalk": {
@@ -11666,13 +11638,6 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -12808,12 +12773,6 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
-    },
-    "node_modules/ordinal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ordinal/-/ordinal-1.0.3.tgz",
-      "integrity": "sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==",
-      "dev": true
     },
     "node_modules/os-locale": {
       "version": "1.4.0",
@@ -16453,143 +16412,11 @@
       }
     },
     "node_modules/whitelist-smart-contract": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/iExecBlockchainComputing/whitelist-smart-contract.git#3581730762daa874299ee33deecd7da39a72b4a8",
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/iExecBlockchainComputing/whitelist-smart-contract.git#670c22c66caf624aef7afa1bde6c8c92d10cd3ac",
       "dev": true,
       "dependencies": {
-        "@nomicfoundation/hardhat-chai-matchers": "^2.0.2",
         "@openzeppelin/contracts": "^4.9.3"
-      }
-    },
-    "node_modules/whitelist-smart-contract/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/whitelist-smart-contract/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/whitelist-smart-contract/node_modules/@nomicfoundation/hardhat-chai-matchers": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.2.tgz",
-      "integrity": "sha512-9Wu9mRtkj0U9ohgXYFbB/RQDa+PcEdyBm2suyEtsJf3PqzZEEjLUZgWnMjlFhATMk/fp3BjmnYVPrwl+gr8oEw==",
-      "dev": true,
-      "dependencies": {
-        "@types/chai-as-promised": "^7.1.3",
-        "chai-as-promised": "^7.1.1",
-        "deep-eql": "^4.0.1",
-        "ordinal": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@nomicfoundation/hardhat-ethers": "^3.0.0",
-        "chai": "^4.2.0",
-        "ethers": "^6.1.0",
-        "hardhat": "^2.9.4"
-      }
-    },
-    "node_modules/whitelist-smart-contract/node_modules/@nomicfoundation/hardhat-ethers": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.4.tgz",
-      "integrity": "sha512-k9qbLoY7qn6C6Y1LI0gk2kyHXil2Tauj4kGzQ8pgxYXIGw8lWn8tuuL72E11CrlKaXRUvOgF0EXrv/msPI2SbA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "lodash.isequal": "^4.5.0"
-      },
-      "peerDependencies": {
-        "ethers": "^6.1.0",
-        "hardhat": "^2.0.0"
-      }
-    },
-    "node_modules/whitelist-smart-contract/node_modules/@types/node": {
-      "version": "18.15.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/whitelist-smart-contract/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/whitelist-smart-contract/node_modules/ethers": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.8.0.tgz",
-      "integrity": "sha512-zrFbmQRlraM+cU5mE4CZTLBurZTs2gdp2ld0nG/f3ecBK+x6lZ69KSxBqZ4NjclxwfTxl5LeNufcBbMsTdY53Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.0",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "18.15.13",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.4.0",
-        "ws": "8.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/whitelist-smart-contract/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/whitelist-smart-contract/node_modules/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/window-size": {

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
     "ts-jest": "^29.1.0",
     "ts-loader": "^9.4.2",
     "typescript": "^4.9.5",
-    "whitelist-smart-contract": "github:iExecBlockchainComputing/whitelist-smart-contract#0.1.0"
+    "whitelist-smart-contract": "github:iExecBlockchainComputing/whitelist-smart-contract#0.2.0"
   },
   "dependencies": {
-    "ethers": "^5.7.2",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/random": "^5.7.0",
+    "ethers": "^5.7.2",
     "graphql-request": "^6.1.0",
     "iexec": "^8.4.0",
     "kubo-rpc-client": "^3.0.1",


### PR DESCRIPTION
 WL addresses as drone repo secret (web3mail-whitelist-dev-address & web3mail-whitelist-prod-address) used by the whitelist scripts instead of adding the contract address manually.

manually add latest web3mail.apps.iexec.eth to WL, in this PR only the dev dapp address is added to the whitelist

integrate “add to whitelist” step in the dapp-prod / dapp-dev CI pipeline (before set ENS)