### PR TITLE
Feature/include dataset order for whitelist in send email method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "yup": "^1.1.1"
       },
       "devDependencies": {
-        "@iexec/dataprotector": "^0.4.0",
+        "@iexec/dataprotector": "^0.4.1",
         "@jest/globals": "^29.7.0",
         "@swc/core": "^1.3.96",
         "@swc/jest": "^0.2.29",
@@ -908,9 +908,9 @@
       "dev": true
     },
     "node_modules/@iexec/dataprotector": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@iexec/dataprotector/-/dataprotector-0.4.0.tgz",
-      "integrity": "sha512-fEff8lv1gvWVE46+4bSPbL9ZArRCRHJihKLvHkM5PFq19MVsxtboUGb/EKvftyhdAaQ+xUP1QJkxZCsaULZh7A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@iexec/dataprotector/-/dataprotector-0.4.1.tgz",
+      "integrity": "sha512-XZIpEl+mWXuzkAbT912aFNbud6t+vbA3xyALDrr4/uePFuaJFzOUIpLM7B3WsCEZN4twTjUgCiZWUR2aEn7DaQ==",
       "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "yup": "^1.1.1"
   },
   "devDependencies": {
-    "@iexec/dataprotector": "^0.4.0",
+    "@iexec/dataprotector": "^0.4.1",
     "@jest/globals": "^29.7.0",
     "@swc/core": "^1.3.96",
     "@swc/jest": "^0.2.29",

--- a/src/web3mail/sendEmail.ts
+++ b/src/web3mail/sendEmail.ts
@@ -17,7 +17,7 @@ import {
   senderNameSchema,
   throwIfMissing,
 } from '../utils/validators.js';
-import * as ipfs from './../utils/ipfs-service.js';
+import * as ipfs from '../utils/ipfs-service.js';
 import {
   DappAddressConsumer,
   IExecConsumer,
@@ -105,19 +105,19 @@ export const sendEmail = async ({
         app: WHITELIST_SMART_CONTRACT_ADDRESS,
         requester: requesterAddress,
       });
-    const datasetWhitelistorder = datasetWhitelistOrderbook?.orders[0]?.order;
     const datasetorder = datasetOrderbook?.orders[0]?.order;
+    const datasetWhitelistorder = datasetWhitelistOrderbook?.orders[0]?.order;
     if (!datasetorder && !datasetWhitelistorder) {
       throw new Error('Dataset order not found');
     }
     const desiredPriceDataOrderbook = datasetOrderbook.orders.filter(
       (order) => order.order.datasetprice <= dataMaxPrice
     );
+    const desiredPriceDataOrder = desiredPriceDataOrderbook[0]?.order;
     const desiredPriceDataWhitelistOrderbook =
       datasetWhitelistOrderbook.orders.filter(
         (order) => order.order.datasetprice <= dataMaxPrice
       );
-    const desiredPriceDataOrder = desiredPriceDataOrderbook[0]?.order;
     if (!desiredPriceDataOrder && !desiredPriceDataWhitelistOrderbook) {
       throw new Error('No Dataset order found for the desired price');
     }

--- a/src/web3mail/sendEmail.ts
+++ b/src/web3mail/sendEmail.ts
@@ -1,8 +1,9 @@
 import {
   DEFAULT_CONTENT_TYPE,
   MAX_DESIRED_APP_ORDER_PRICE,
-  MAX_DESIRED_WORKERPOOL_ORDER_PRICE,
   MAX_DESIRED_DATA_ORDER_PRICE,
+  MAX_DESIRED_WORKERPOOL_ORDER_PRICE,
+  WHITELIST_SMART_CONTRACT_ADDRESS,
 } from '../config/config.js';
 import { WorkflowError } from '../utils/errors.js';
 import { generateSecureUniqueId } from '../utils/generateUniqueId.js';
@@ -12,20 +13,20 @@ import {
   contentTypeSchema,
   emailContentSchema,
   emailSubjectSchema,
-  senderNameSchema,
   labelSchema,
+  senderNameSchema,
   throwIfMissing,
 } from '../utils/validators.js';
+import * as ipfs from './../utils/ipfs-service.js';
 import {
+  DappAddressConsumer,
   IExecConsumer,
+  IpfsGatewayConfigConsumer,
+  IpfsNodeConfigConsumer,
   SendEmailParams,
   SendEmailResponse,
   SubgraphConsumer,
-  DappAddressConsumer,
-  IpfsNodeConfigConsumer,
-  IpfsGatewayConfigConsumer,
 } from './types.js';
-import * as ipfs from './../utils/ipfs-service.js';
 
 export const sendEmail = async ({
   graphQLClient = throwIfMissing(),
@@ -98,15 +99,26 @@ export const sendEmail = async ({
         requester: requesterAddress,
       }
     );
+    // Fetch dataset order for whitelist address
+    const datasetWhitelistOrderbook =
+      await iexec.orderbook.fetchDatasetOrderbook(vDatasetAddress, {
+        app: WHITELIST_SMART_CONTRACT_ADDRESS,
+        requester: requesterAddress,
+      });
+    const datasetWhitelistorder = datasetWhitelistOrderbook?.orders[0]?.order;
     const datasetorder = datasetOrderbook?.orders[0]?.order;
-    if (!datasetorder) {
+    if (!datasetorder && !datasetWhitelistorder) {
       throw new Error('Dataset order not found');
     }
     const desiredPriceDataOrderbook = datasetOrderbook.orders.filter(
       (order) => order.order.datasetprice <= dataMaxPrice
     );
+    const desiredPriceDataWhitelistOrderbook =
+      datasetWhitelistOrderbook.orders.filter(
+        (order) => order.order.datasetprice <= dataMaxPrice
+      );
     const desiredPriceDataOrder = desiredPriceDataOrderbook[0]?.order;
-    if (!desiredPriceDataOrder) {
+    if (!desiredPriceDataOrder && !desiredPriceDataWhitelistOrderbook) {
       throw new Error('No Dataset order found for the desired price');
     }
 
@@ -209,7 +221,7 @@ export const sendEmail = async ({
     // Match orders and compute task ID
     const { dealid } = await iexec.order.matchOrders({
       apporder: desiredPriceAppOrder,
-      datasetorder: datasetorder,
+      datasetorder: datasetorder ? datasetorder : datasetWhitelistorder,
       workerpoolorder: desiredPriceWorkerpoolOrder,
       requestorder: requestorder,
     });


### PR DESCRIPTION
Presentation

Currently: We didn’t have a correct implementation for sendEmail function. Indeed, we need to fetchDatasetOrders for protectedData with appRestrict : web3mail_dapp_ens & whitelist_smart_contract

Objective: We need fetchDatasetOrders for protectedData with appRestrict : web3mail_dapp_ens + whitelist_smart_contract.

Fetch both orders for protected with appRestrict web3mail_dapp_ens & whitelist_smart_contract.