### PR TITLE
add e2e tests of web3mail constructor

### DIFF
--- a/tests/e2e/constructor.test.ts
+++ b/tests/e2e/constructor.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/dot-notation */
+// needed to access and assert IExecDataProtector's private properties
 import { describe, expect, it } from '@jest/globals';
 import { Wallet } from 'ethers';
 import { getSignerFromPrivateKey } from 'iexec/utils';
@@ -23,6 +24,7 @@ describe('IExecWeb3mail()', () => {
     );
     expect(web3mail).toBeInstanceOf(IExecWeb3mail);
   });
+
   it('should use default ipfs gateway url when ipfsGateway is not provided', async () => {
     const wallet = Wallet.createRandom();
     const web3mail = new IExecWeb3mail(
@@ -31,7 +33,8 @@ describe('IExecWeb3mail()', () => {
     const ipfsGateway = web3mail['ipfsGateway'];
     expect(ipfsGateway).toStrictEqual(DEFAULT_IPFS_GATEWAY);
   });
-  it('should use default ipfs gateway url when ipfsGateway is provided', async () => {
+
+  it('should use provided ipfs gateway url when ipfsGateway is provided', async () => {
     const customIpfsGateway = 'https://example.com/ipfs_gateway';
     const wallet = Wallet.createRandom();
     const web3mail = new IExecWeb3mail(
@@ -43,6 +46,7 @@ describe('IExecWeb3mail()', () => {
     const ipfsGateway = web3mail['ipfsGateway'];
     expect(ipfsGateway).toStrictEqual(customIpfsGateway);
   });
+
   it('should use default data Protector Subgraph URL when subgraphUrl is not provided', async () => {
     const wallet = Wallet.createRandom();
     const web3mail = new IExecWeb3mail(
@@ -51,6 +55,7 @@ describe('IExecWeb3mail()', () => {
     const graphQLClientUrl = web3mail['graphQLClient'];
     expect(graphQLClientUrl['url']).toBe(DATAPROTECTOR_SUBGRAPH_ENDPOINT);
   });
+
   it('should use provided data Protector Subgraph URL when subgraphUrl is provided', async () => {
     const customSubgraphUrl = 'https://example.com/custom-subgraph';
     const wallet = Wallet.createRandom();
@@ -72,19 +77,20 @@ describe('IExecWeb3mail()', () => {
     const customIpfsNode = 'https://example.com/node';
     const smsURL = 'https://custom-sms-url.com';
     const iexecGatewayURL = 'https://custom-market-api-url.com';
-    const dappWhitelistAddress = '0x781482C39CcE25546583EaC4957Fb7Bf04C277BB';
+    const customDappWhitelistAddress =
+      '0x781482C39CcE25546583EaC4957Fb7Bf04C277BB';
     const web3mail = new IExecWeb3mail(
       getSignerFromPrivateKey('https://bellecour.iex.ec', wallet.privateKey),
       {
         iexecOptions: {
-          smsURL: smsURL,
-          iexecGatewayURL: iexecGatewayURL,
+          smsURL,
+          iexecGatewayURL,
         },
         ipfsNode: customIpfsNode,
         ipfsGateway: customIpfsGateway,
         dataProtectorSubgraph: customSubgraphUrl,
         dappAddressOrENS: customDapp,
-        dappWhitelistAddress: dappWhitelistAddress,
+        dappWhitelistAddress: customDappWhitelistAddress,
       }
     );
     const graphQLClient = web3mail['graphQLClient'];
@@ -98,7 +104,7 @@ describe('IExecWeb3mail()', () => {
     expect(ipfsNode).toStrictEqual(customIpfsNode);
     expect(ipfsGateway).toStrictEqual(customIpfsGateway);
     expect(dappAddressOrENS).toStrictEqual(customDapp);
-    expect(whitelistAddress).toStrictEqual(dappWhitelistAddress);
+    expect(whitelistAddress).toStrictEqual(customDappWhitelistAddress);
     expect(await iexec.config.resolveSmsURL()).toBe(smsURL);
     expect(await iexec.config.resolveIexecGatewayURL()).toBe(iexecGatewayURL);
   });

--- a/tests/e2e/constructor.test.ts
+++ b/tests/e2e/constructor.test.ts
@@ -1,6 +1,11 @@
+/* eslint-disable @typescript-eslint/dot-notation */
 import { describe, expect, it } from '@jest/globals';
 import { Wallet } from 'ethers';
 import { getSignerFromPrivateKey } from 'iexec/utils';
+import {
+  DATAPROTECTOR_SUBGRAPH_ENDPOINT,
+  DEFAULT_IPFS_GATEWAY,
+} from '../../src/config/config.js';
 import { IExecWeb3mail } from '../../src/index.js';
 
 describe('IExecWeb3mail()', () => {
@@ -18,23 +23,83 @@ describe('IExecWeb3mail()', () => {
     );
     expect(web3mail).toBeInstanceOf(IExecWeb3mail);
   });
-
-  it('instantiates with custom web3Mail config options', async () => {
+  it('should use default ipfs gateway url when ipfsGateway is not provided', async () => {
+    const wallet = Wallet.createRandom();
+    const web3mail = new IExecWeb3mail(
+      getSignerFromPrivateKey('https://bellecour.iex.ec', wallet.privateKey)
+    );
+    const ipfsGateway = web3mail['ipfsGateway'];
+    expect(ipfsGateway).toStrictEqual(DEFAULT_IPFS_GATEWAY);
+  });
+  it('should use default ipfs gateway url when ipfsGateway is provided', async () => {
+    const customIpfsGateway = 'https://example.com/ipfs_gateway';
     const wallet = Wallet.createRandom();
     const web3mail = new IExecWeb3mail(
       getSignerFromPrivateKey('https://bellecour.iex.ec', wallet.privateKey),
       {
-        iexecOptions: {
-          smsURL: 'https://sms.scone-debug.stagingv8.iex.ec',
-          iexecGatewayURL: 'https://api.market.stagingv8.iex.ec',
-        },
-        ipfsNode: 'https://example.com/node',
-        ipfsGateway: 'https://example.com/ipfs_gateway',
-        dataProtectorSubgraph: 'https://example.com/custom-subgraph',
-        dappAddressOrENS: 'web3mailstg.apps.iexec.eth',
-        dappWhitelistAddress: '0x781482C39CcE25546583EaC4957Fb7Bf04C277BB',
+        ipfsGateway: customIpfsGateway,
       }
     );
-    expect(web3mail).toBeInstanceOf(IExecWeb3mail);
+    const ipfsGateway = web3mail['ipfsGateway'];
+    expect(ipfsGateway).toStrictEqual(customIpfsGateway);
+  });
+  it('should use default data Protector Subgraph URL when subgraphUrl is not provided', async () => {
+    const wallet = Wallet.createRandom();
+    const web3mail = new IExecWeb3mail(
+      getSignerFromPrivateKey('https://bellecour.iex.ec', wallet.privateKey)
+    );
+    const graphQLClientUrl = web3mail['graphQLClient'];
+    expect(graphQLClientUrl['url']).toBe(DATAPROTECTOR_SUBGRAPH_ENDPOINT);
+  });
+  it('should use provided data Protector Subgraph URL when subgraphUrl is provided', async () => {
+    const customSubgraphUrl = 'https://example.com/custom-subgraph';
+    const wallet = Wallet.createRandom();
+    const web3mail = new IExecWeb3mail(
+      getSignerFromPrivateKey('https://bellecour.iex.ec', wallet.privateKey),
+      {
+        dataProtectorSubgraph: customSubgraphUrl,
+      }
+    );
+    const graphQLClient = web3mail['graphQLClient'];
+    expect(graphQLClient['url']).toBe(customSubgraphUrl);
+  });
+
+  it('instantiates with custom web3Mail config options', async () => {
+    const wallet = Wallet.createRandom();
+    const customSubgraphUrl = 'https://example.com/custom-subgraph';
+    const customIpfsGateway = 'https://example.com/ipfs_gateway';
+    const customDapp = 'web3mailstg.apps.iexec.eth';
+    const customIpfsNode = 'https://example.com/node';
+    const smsURL = 'https://custom-sms-url.com';
+    const iexecGatewayURL = 'https://custom-market-api-url.com';
+    const dappWhitelistAddress = '0x781482C39CcE25546583EaC4957Fb7Bf04C277BB';
+    const web3mail = new IExecWeb3mail(
+      getSignerFromPrivateKey('https://bellecour.iex.ec', wallet.privateKey),
+      {
+        iexecOptions: {
+          smsURL: smsURL,
+          iexecGatewayURL: iexecGatewayURL,
+        },
+        ipfsNode: customIpfsNode,
+        ipfsGateway: customIpfsGateway,
+        dataProtectorSubgraph: customSubgraphUrl,
+        dappAddressOrENS: customDapp,
+        dappWhitelistAddress: dappWhitelistAddress,
+      }
+    );
+    const graphQLClient = web3mail['graphQLClient'];
+    const ipfsNode = web3mail['ipfsNode'];
+    const ipfsGateway = web3mail['ipfsGateway'];
+    const dappAddressOrENS = web3mail['dappAddressOrENS'];
+    const iexec = web3mail['iexec'];
+    const whitelistAddress = web3mail['dappWhitelistAddress'];
+
+    expect(graphQLClient['url']).toBe(customSubgraphUrl);
+    expect(ipfsNode).toStrictEqual(customIpfsNode);
+    expect(ipfsGateway).toStrictEqual(customIpfsGateway);
+    expect(dappAddressOrENS).toStrictEqual(customDapp);
+    expect(whitelistAddress).toStrictEqual(dappWhitelistAddress);
+    expect(await iexec.config.resolveSmsURL()).toBe(smsURL);
+    expect(await iexec.config.resolveIexecGatewayURL()).toBe(iexecGatewayURL);
   });
 });


### PR DESCRIPTION
There are no tests whose checks the correct initialization of the private variables of the constructor. 

Objective: Harmonize with tests as dataprotector-sdk

what's done:  added the necessary e2e test to the constructor