### PR TITLE
use buffer polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## NEXT
+
+### Changed
+
+- fixed `Buffer` polyfill issue
+
 ## [0.6.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/random": "^5.7.0",
+        "buffer": "^6.0.3",
         "ethers": "^6.8.1",
         "graphql-request": "^6.1.0",
         "iexec": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/random": "^5.7.0",
+    "buffer": "^6.0.3",
     "ethers": "^6.8.1",
     "graphql-request": "^6.1.0",
     "iexec": "^8.6.0",

--- a/src/web3mail/sendEmail.ts
+++ b/src/web3mail/sendEmail.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import {
   DEFAULT_CONTENT_TYPE,
   MAX_DESIRED_APP_ORDER_PRICE,


### PR DESCRIPTION
fix `Buffer is not defined` issue encoutered in browser when the bundler does not handle `Buffer` polyfill

NB: the added dependency on `buffer` does not add to the bundle size as `buffer` was already a transient dependency
```sh
$ npm ls buffer

@iexec/web3mail@0.6.0
├── buffer@6.0.3
├─┬ iexec@8.6.1
│ ├── buffer@6.0.3 deduped
│ ├─┬ inquirer@9.2.11
│ │ └─┬ ora@5.4.1
│ │   └─┬ bl@4.1.0
│ │     └── buffer@5.7.1
│ └─┬ ora@7.0.1
│   └─┬ stdin-discarder@0.1.0
│     └─┬ bl@5.1.0
│       └── buffer@6.0.3 deduped
└─┬ kubo-rpc-client@3.0.1
  ├─┬ ipfs-core-utils@0.18.1
  │ └─┬ it-to-stream@1.0.0
  │   └── buffer@6.0.3 deduped
  └─┬ ipfs-utils@9.0.14
    └── buffer@6.0.3 deduped
```