### PR TITLE
Don't hide Validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.2]
+
+### Changed
+
+- be able to call `fetchMyContacts` with `isUserStrict` param
+
 ## [1.0.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.3]
+
+### Changed
+
+- remove unnecessary initialization of storage in `sendEmail`
+
 ## [1.0.2]
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iexec/web3mail",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iexec/web3mail",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iexec/web3mail",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iexec/web3mail",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iexec/web3mail",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "This product enables users to confidentially store data–such as mail address, documents, personal information ...",
   "main": "./dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iexec/web3mail",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "This product enables users to confidentially store data–such as mail address, documents, personal information ...",
   "main": "./dist/index.js",
   "type": "module",

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,4 +1,5 @@
 import { ApiCallError } from 'iexec/errors';
+
 export class WorkflowError extends Error {
   isProtocolError: boolean;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export { ValidationError } from 'yup';
 export { WorkflowError } from './errors.js';

--- a/src/web3mail/IExecWeb3mail.ts
+++ b/src/web3mail/IExecWeb3mail.ts
@@ -11,6 +11,7 @@ import {
   Web3MailConfigOptions,
   SendEmailResponse,
   Web3SignerProvider,
+  FetchMyContactsParams,
 } from './types.js';
 import { GraphQLClient } from 'graphql-request';
 import {
@@ -65,9 +66,10 @@ export class IExecWeb3mail {
       options?.dappWhitelistAddress || WHITELIST_SMART_CONTRACT_ADDRESS;
   }
 
-  async fetchMyContacts(): Promise<Contact[]> {
+  async fetchMyContacts(args?: FetchMyContactsParams): Promise<Contact[]> {
     await isValidProvider(this.iexec);
     return fetchMyContacts({
+      ...args,
       iexec: this.iexec,
       graphQLClient: this.graphQLClient,
       dappAddressOrENS: this.dappAddressOrENS,
@@ -75,7 +77,7 @@ export class IExecWeb3mail {
     });
   }
 
-  fetchUserContacts(args?: FetchUserContactsParams): Promise<Contact[]> {
+  fetchUserContacts(args: FetchUserContactsParams): Promise<Contact[]> {
     return fetchUserContacts({
       ...args,
       iexec: this.iexec,

--- a/src/web3mail/fetchUserContacts.ts
+++ b/src/web3mail/fetchUserContacts.ts
@@ -30,23 +30,23 @@ export const fetchUserContacts = async ({
   DappAddressConsumer &
   DappWhitelistAddressConsumer &
   FetchUserContactsParams): Promise<Contact[]> => {
-  try {
-    const vDappAddressOrENS = addressOrEnsSchema()
-      .required()
-      .label('dappAddressOrENS')
-      .validateSync(dappAddressOrENS);
-    const vDappWhitelistAddress = addressSchema()
-      .required()
-      .label('dappWhitelistAddress')
-      .validateSync(dappWhitelistAddress);
-    const vUserAddress = addressOrEnsSchema()
-      .required()
-      .label('userAddress')
-      .validateSync(userAddress);
-    const vIsUserStrict = booleanSchema()
-      .label('isUserStrict')
-      .validateSync(isUserStrict);
+  const vDappAddressOrENS = addressOrEnsSchema()
+    .required()
+    .label('dappAddressOrENS')
+    .validateSync(dappAddressOrENS);
+  const vDappWhitelistAddress = addressSchema()
+    .required()
+    .label('dappWhitelistAddress')
+    .validateSync(dappWhitelistAddress);
+  const vUserAddress = addressOrEnsSchema()
+    .required()
+    .label('userAddress')
+    .validateSync(userAddress);
+  const vIsUserStrict = booleanSchema()
+    .label('isUserStrict')
+    .validateSync(isUserStrict);
 
+  try {
     const [dappOrders, whitelistOrders] = await Promise.all([
       fetchAllOrdersByApp({
         iexec,

--- a/src/web3mail/sendEmail.ts
+++ b/src/web3mail/sendEmail.ts
@@ -56,49 +56,49 @@ export const sendEmail = async ({
   IpfsNodeConfigConsumer &
   IpfsGatewayConfigConsumer &
   SendEmailParams): Promise<SendEmailResponse> => {
-  try {
-    const vDatasetAddress = addressOrEnsSchema()
-      .required()
-      .label('protectedData')
-      .validateSync(protectedData);
-    const vEmailSubject = emailSubjectSchema()
-      .required()
-      .label('emailSubject')
-      .validateSync(emailSubject);
-    const vEmailContent = emailContentSchema()
-      .required()
-      .label('emailContent')
-      .validateSync(emailContent);
-    const vContentType = contentTypeSchema()
-      .required()
-      .label('contentType')
-      .validateSync(contentType);
-    const vSenderName = senderNameSchema()
-      .label('senderName')
-      .validateSync(senderName);
-    const vLabel = labelSchema().label('label').validateSync(label);
-    const vWorkerpoolAddressOrEns = addressOrEnsSchema()
-      .required()
-      .label('WorkerpoolAddressOrEns')
-      .validateSync(workerpoolAddressOrEns);
-    const vDappAddressOrENS = addressOrEnsSchema()
-      .required()
-      .label('dappAddressOrENS')
-      .validateSync(dappAddressOrENS);
-    const vDappWhitelistAddress = addressSchema()
-      .required()
-      .label('dappWhitelistAddress')
-      .validateSync(dappWhitelistAddress);
-    const vDataMaxPrice = positiveNumberSchema()
-      .label('dataMaxPrice')
-      .validateSync(dataMaxPrice);
-    const vAppMaxPrice = positiveNumberSchema()
-      .label('appMaxPrice')
-      .validateSync(appMaxPrice);
-    const vWorkerpoolMaxPrice = positiveNumberSchema()
-      .label('workerpoolMaxPrice')
-      .validateSync(workerpoolMaxPrice);
+  const vDatasetAddress = addressOrEnsSchema()
+    .required()
+    .label('protectedData')
+    .validateSync(protectedData);
+  const vEmailSubject = emailSubjectSchema()
+    .required()
+    .label('emailSubject')
+    .validateSync(emailSubject);
+  const vEmailContent = emailContentSchema()
+    .required()
+    .label('emailContent')
+    .validateSync(emailContent);
+  const vContentType = contentTypeSchema()
+    .required()
+    .label('contentType')
+    .validateSync(contentType);
+  const vSenderName = senderNameSchema()
+    .label('senderName')
+    .validateSync(senderName);
+  const vLabel = labelSchema().label('label').validateSync(label);
+  const vWorkerpoolAddressOrEns = addressOrEnsSchema()
+    .required()
+    .label('WorkerpoolAddressOrEns')
+    .validateSync(workerpoolAddressOrEns);
+  const vDappAddressOrENS = addressOrEnsSchema()
+    .required()
+    .label('dappAddressOrENS')
+    .validateSync(dappAddressOrENS);
+  const vDappWhitelistAddress = addressSchema()
+    .required()
+    .label('dappWhitelistAddress')
+    .validateSync(dappWhitelistAddress);
+  const vDataMaxPrice = positiveNumberSchema()
+    .label('dataMaxPrice')
+    .validateSync(dataMaxPrice);
+  const vAppMaxPrice = positiveNumberSchema()
+    .label('appMaxPrice')
+    .validateSync(appMaxPrice);
+  const vWorkerpoolMaxPrice = positiveNumberSchema()
+    .label('workerpoolMaxPrice')
+    .validateSync(workerpoolMaxPrice);
 
+  try {
     // Check protected data validity through subgraph
     const isValidProtectedData = await checkProtectedDataValidity(
       graphQLClient,
@@ -259,7 +259,7 @@ export const sendEmail = async ({
     handleIfProtocolError(error);
 
     throw new WorkflowError({
-      message: 'Failed to sendEmail',
+      message: 'Failed to send email',
       errorCause: error,
     });
   }

--- a/src/web3mail/sendEmail.ts
+++ b/src/web3mail/sendEmail.ts
@@ -110,14 +110,6 @@ export const sendEmail = async ({
 
     const requesterAddress = await iexec.wallet.getAddress();
 
-    // Initialize IPFS storage if not already initialized
-    const isIpfsStorageInitialized =
-      await iexec.storage.checkStorageTokenExists(requesterAddress);
-    if (!isIpfsStorageInitialized) {
-      const token = await iexec.storage.defaultStorageLogin();
-      await iexec.storage.pushStorageToken(token);
-    }
-
     const [
       datasetorderForApp,
       datasetorderForWhitelist,


### PR DESCRIPTION
Imagine I'm a new builder playing with web3mail-sdk, I'm trying to send an email.
I enter only two characters for `senderName` parameter.

**Before:**

👎 Real "Validation error" hidden behind a not-so-useful Workflow error...

<img width="1485" alt="Capture d’écran 2024-08-02 à 11 11 12" src="https://github.com/user-attachments/assets/ed75f85c-fb05-407d-a01d-4b6dbe7110bd">

**After:**

👍 "Validation error" returned as-is.

<img width="1489" alt="Capture d’écran 2024-08-02 à 11 19 59" src="https://github.com/user-attachments/assets/58b1adff-994b-4d1c-9145-37006ab1faf8">
