### PR TITLE
Bump kubo-rpc-client v3 to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "ethers": "^6.13.2",
         "graphql-request": "^6.1.0",
         "iexec": "^8.10.0",
-        "kubo-rpc-client": "^3.0.1",
+        "kubo-rpc-client": "^4.1.1",
         "yup": "^1.1.1"
       },
       "devDependencies": {
@@ -860,9 +860,10 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -926,6 +927,125 @@
         "magic-bytes.js": "^1.0.15",
         "typescript": "^4.9.5",
         "yup": "^1.0.2"
+      }
+    },
+    "node_modules/@iexec/dataprotector/node_modules/@libp2p/logger": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.1.1.tgz",
+      "integrity": "sha512-2UbzDPctg3cPupF6jrv6abQnAUTrbLybNOj0rmmrdGm1cN2HJ1o/hBu0sXuq4KF9P1h/eVRn1HIRbVIEKnEJrA==",
+      "dev": true,
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.2",
+        "@multiformats/multiaddr": "^12.1.3",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@iexec/dataprotector/node_modules/@libp2p/peer-id": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.4.tgz",
+      "integrity": "sha512-gcOsN8Fbhj6izIK+ejiWsqiqKeJ2yWPapi/m55VjOvDa52/ptQzZszxQP8jUk93u36de92ATFXDfZR/Bi6eeUQ==",
+      "dev": true,
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@iexec/dataprotector/node_modules/any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==",
+      "dev": true
+    },
+    "node_modules/@iexec/dataprotector/node_modules/dag-jose": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-4.0.0.tgz",
+      "integrity": "sha512-tw595L3UYoOUT9dSJPbBEG/qpRpw24kRZxa5SLRnlnr+g5L7O8oEs1d3W5TiVA1oJZbthVsf0Vi3zFN66qcEBA==",
+      "dev": true,
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "multiformats": "^11.0.0"
+      }
+    },
+    "node_modules/@iexec/dataprotector/node_modules/it-first": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
+      "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@iexec/dataprotector/node_modules/it-last": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.1.tgz",
+      "integrity": "sha512-uVMedYW0wa2Cx0TAmcOCLbfuLLII7+vyURmhKa8Zovpd+aBTMsmINtsta2n364wJ5qsEDBH+akY1sUtAkaYBlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@iexec/dataprotector/node_modules/kubo-rpc-client": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/kubo-rpc-client/-/kubo-rpc-client-3.0.4.tgz",
+      "integrity": "sha512-MV8XFG8ikSPZJkzN/h50SH60kyFz6d3hBcHE/ChhLmbzT3TM8n/I9fq0+5IL5dFSwJo5YrpZqDgsFhNgMSeztg==",
+      "dev": true,
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.1.10",
+        "any-signal": "^3.0.1",
+        "dag-jose": "^4.0.0",
+        "err-code": "^3.0.1",
+        "ipfs-core-utils": "^0.18.0",
+        "ipfs-utils": "^9.0.7",
+        "it-first": "^2.0.0",
+        "it-last": "^2.0.0",
+        "merge-options": "^3.0.4",
+        "multiformats": "^11.0.0",
+        "parse-duration": "^1.0.2",
+        "stream-to-it": "^0.2.4",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@iexec/dataprotector/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@iexec/dataprotector/node_modules/stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+      "dev": true,
+      "dependencies": {
+        "get-iterator": "^1.0.2"
       }
     },
     "node_modules/@iexec/dataprotector/node_modules/typescript": {
@@ -997,17 +1117,22 @@
       "integrity": "sha512-Ts7h4/5tNiRN2iiH10Mp+6CgmK/PETDHYIJ/tpUrXgGjWR51T/Dr8kxa41GeHHhmAsuo+CkcuG9L4di6qth/Mw=="
     },
     "node_modules/@ipld/dag-cbor": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.6.tgz",
-      "integrity": "sha512-3kNab5xMppgWw6DVYx2BzmFq8t7I56AGWfp5kaU1fIPkwHVpBRglJJTYsGtbVluCi/s/q97HZM3bC+aDW4sxbQ==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.1.tgz",
+      "integrity": "sha512-nyY48yE7r3dnJVlxrdaimrbloh4RokQaNRdI//btfTkcTEZbpmSrbYcBQ4VKTf8ZxXAOUJy4VsRpkJo+y9RTnA==",
       "dependencies": {
         "cborg": "^4.0.0",
-        "multiformats": "^12.0.1"
+        "multiformats": "^13.1.0"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
     },
     "node_modules/@ipld/dag-json": {
       "version": "10.1.5",
@@ -1023,16 +1148,21 @@
       }
     },
     "node_modules/@ipld/dag-pb": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.6.tgz",
-      "integrity": "sha512-wOij3jfDKZsb9yjhQeHp+TQy0pu1vmUkGv324xciFFZ7xGbDfAGTQW03lSA5aJ/7HBBNYgjEE0nvHmNW1Qjfag==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.2.tgz",
+      "integrity": "sha512-BSztO4l3C+ya9HjCaQot26Y4AVsqIKtnn6+23ubc1usucnf6yoTBme18oCCdM6gKBMxuPqju5ye3lh9WEJsdeQ==",
       "dependencies": {
-        "multiformats": "^12.0.1"
+        "multiformats": "^13.1.0"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1514,6 +1644,7 @@
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.17.tgz",
       "integrity": "sha512-Oeg0Eb/EvAho0gVkOgemXEgrVxWaT3x/DpFgkBdZ9qGxwq75w/E/oPc7souqBz+l1swfz37GWnwV7bIb4Xv5Ag==",
+      "dev": true,
       "dependencies": {
         "@libp2p/interface-keys": "^1.0.2",
         "@libp2p/interfaces": "^3.2.0",
@@ -1534,30 +1665,30 @@
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
       "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@libp2p/interface": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.5.tgz",
-      "integrity": "sha512-1sPZ0iZifINtw8RAZ6flML7InRXNkZJF/MpKmAwIFXhEFDtRvbwMSs/kihPxLgsvbBCfJiTqUuy2ki8a4p06Vg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.6.3.tgz",
+      "integrity": "sha512-Tm8W5Q2FsjcSdeA5BvP/GTUq/lp3SjeW6GPmWbbIasBJdv67UGHahu8YDFTME90IxTijnikkfGNkOPsd/4UuvA==",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.1.5",
-        "abortable-iterator": "^5.0.1",
-        "it-pushable": "^3.2.0",
+        "@multiformats/multiaddr": "^12.2.3",
+        "it-pushable": "^3.2.3",
         "it-stream-types": "^2.0.1",
-        "multiformats": "^12.0.1",
-        "p-defer": "^4.0.0",
-        "race-signal": "^1.0.0",
-        "uint8arraylist": "^2.4.3"
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
       }
     },
     "node_modules/@libp2p/interface-connection": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
       "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "dev": true,
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
@@ -1574,6 +1705,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.5.tgz",
       "integrity": "sha512-I88Ka1nHgfX62e5mi5LLL+oueqz7Ltg0bUdtsUKDe9SoUqbQPf2Mp5kxDTe9pNhHQGs4pvYPAINwuZ1HAt42TA==",
+      "dev": true,
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -1583,6 +1715,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.5.tgz",
       "integrity": "sha512-mb7QNgn9fIvC7CaJCi06GJ+a6DN6RVT9TmEi0NmedZGATeCArPeWWG7r7IfxNVXb9cVOOE1RzV1swK0ZxEJF9Q==",
+      "dev": true,
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "multiformats": "^11.0.0"
@@ -1596,6 +1729,7 @@
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
       "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -1605,6 +1739,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.8.tgz",
       "integrity": "sha512-CJ1SlrwuoHMquhEEWS77E+4vv7hwB7XORkqzGQrPQmA9MRdIEZRS64bA4JqCLUDa4ltH0l+U1vp0oZHLT67NEA==",
+      "dev": true,
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -1614,6 +1749,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
       "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "dev": true,
       "dependencies": {
         "multiformats": "^11.0.0"
       },
@@ -1626,6 +1762,7 @@
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
       "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -1635,6 +1772,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.10.tgz",
       "integrity": "sha512-HQlo8NwQjMyamCHJrnILEZz+YwEOXCB2sIIw3slIrhVUYeYlTaia1R6d9umaAeLHa255Zmdm4qGH8rJLRqhCcg==",
+      "dev": true,
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@multiformats/multiaddr": "^12.0.0"
@@ -1648,6 +1786,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.7.tgz",
       "integrity": "sha512-+c74EVUBTfw2sx1GE/z/IjsYO6dhur+ukF0knAppeZsRQ1Kgg6K5R3eECtT28fC6dBWLjFpAvW/7QGfiDAL4RA==",
+      "dev": true,
       "dependencies": {
         "@libp2p/interface-connection": "^4.0.0",
         "@libp2p/interface-peer-id": "^2.0.0",
@@ -1660,62 +1799,59 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
+    },
     "node_modules/@libp2p/interfaces": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.2.tgz",
       "integrity": "sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g==",
+      "dev": true,
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.1.1.tgz",
-      "integrity": "sha512-2UbzDPctg3cPupF6jrv6abQnAUTrbLybNOj0rmmrdGm1cN2HJ1o/hBu0sXuq4KF9P1h/eVRn1HIRbVIEKnEJrA==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.19.tgz",
+      "integrity": "sha512-VKpIMbjzs60AaTezh55iEDPJ0W2icbkJkBXSlAMycCT4C+RYxOTRgevasw3mDB6+Lj9etM0nfa4vutoG4fsYCw==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^2.0.2",
-        "@multiformats/multiaddr": "^12.1.3",
-        "debug": "^4.3.4",
-        "interface-datastore": "^8.2.0",
-        "multiformats": "^11.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "@libp2p/interface": "^1.6.3",
+        "@multiformats/multiaddr": "^12.2.3",
+        "interface-datastore": "^8.2.11",
+        "multiformats": "^13.1.0",
+        "weald": "^1.0.2"
       }
     },
     "node_modules/@libp2p/logger/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.4.tgz",
-      "integrity": "sha512-gcOsN8Fbhj6izIK+ejiWsqiqKeJ2yWPapi/m55VjOvDa52/ptQzZszxQP8jUk93u36de92ATFXDfZR/Bi6eeUQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-4.2.3.tgz",
+      "integrity": "sha512-hRqPzcYOz/5q6QvHYdmPMGeFZCjC/9qxQ/+jstSDMnY1DuKEXCre2+tCpG9OeRAFyPBbs5isfaqbY3zNZV2pqA==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interfaces": "^3.2.0",
-        "multiformats": "^11.0.0",
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "@libp2p/interface": "^1.6.3",
+        "multiformats": "^13.1.0",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-id/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
+    },
+    "node_modules/@libp2p/peer-id/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/@ljharb/through": {
@@ -1729,30 +1865,66 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.6.tgz",
+      "integrity": "sha512-nt/5UqjMPtyvkG9BQYdJ4GfLK3nMqGpFZOzf4hAmIa0sJh2LlS9YKXZ4FgwBDsaHvzZqR/rUFIywIc7pkHNNuw==",
+      "dependencies": {
+        "@types/dns-packet": "^5.6.5",
+        "buffer": "^6.0.3",
+        "dns-packet": "^5.6.1",
+        "hashlru": "^2.3.0",
+        "p-queue": "^8.0.1",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^5.0.2"
+      }
+    },
+    "node_modules/@multiformats/dns/node_modules/multiformats": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
+    },
+    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/@multiformats/multiaddr": {
-      "version": "12.1.10",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.10.tgz",
-      "integrity": "sha512-Bi3nJ/SE17+te40OLxFOpr9CvRodusZZLYZb3e5a0w9RzQcHzfKnnlfqdysLXZ2W5vXgxCUL/Uhndl51Ff2S+Q==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.3.0.tgz",
+      "integrity": "sha512-JQ8Gc/jgucqqvEaDTFN/AvxlYDHEE7lgEWLMYW7hKZkWggER+GvG/tVxUgUxIP8M0vFpvEHKKHE0lKzyMsgi8Q==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/interface": "^0.1.1",
-        "dns-over-http-resolver": "3.0.0",
-        "multiformats": "^12.0.1",
+        "@libp2p/interface": "^1.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "multiformats": "^13.0.0",
         "uint8-varint": "^2.0.1",
-        "uint8arrays": "^4.0.2"
+        "uint8arrays": "^5.0.0"
       }
     },
     "node_modules/@multiformats/multiaddr-to-uri": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.7.tgz",
-      "integrity": "sha512-i3ldtPMN6XJt+MCi34hOl0wGuGEHfWWMw6lmNag5BpckPwPTf9XGOOFMmh7ed/uO3Vjah/g173iOe61HTQVoBA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-10.1.0.tgz",
+      "integrity": "sha512-ZNwSAx3ssBWwd4y0LKrOsq9xG7LBHboQxnUdSduNc2fTh/NS1UjA2slgUy6KHxH5k9S2DSus0iU2CoyJyN0/pg==",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "@multiformats/multiaddr": "^12.3.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/@noble/curves": {
@@ -1770,6 +1942,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
       "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1792,6 +1965,7 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
       "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1842,27 +2016,32 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -1871,27 +2050,32 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "dev": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "dev": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -2184,6 +2368,14 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/dns-packet": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
+      "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -2242,7 +2434,8 @@
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "20.8.10",
@@ -2502,19 +2695,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/abortable-iterator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
-      "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
-      "dependencies": {
-        "get-iterator": "^2.0.0",
-        "it-stream-types": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
@@ -2605,9 +2785,13 @@
       }
     },
     "node_modules/any-signal": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
-      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -2921,9 +3105,9 @@
       }
     },
     "node_modules/blob-to-it": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-2.0.4.tgz",
-      "integrity": "sha512-1z2a98yY7v855TreA3HzwJs/j7ecMzes6U1ty8fJ93S1XbiETsup+h5DA/XBMwK3tBu+CWx4WJjR3b8S13TKeQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-2.0.7.tgz",
+      "integrity": "sha512-mFAR/GKDDqFOkSBB7shXfsUZwU5DgK453++I8/SImNacfJsdKlx/oHTO0T4ZYHz8A2dnSONE+CX8L29VlWGKiQ==",
       "dependencies": {
         "browser-readablestream-to-it": "^2.0.0"
       }
@@ -2937,6 +3121,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2955,9 +3140,9 @@
       }
     },
     "node_modules/browser-readablestream-to-it": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.4.tgz",
-      "integrity": "sha512-EOjEEA+tJInvKg/Pml6QYxVY6gD8lka/ceLmkUbEeuWlzZx/a5k5ugupVFUUKSfI/88+v0VFs7JSFi5iYpp3IA=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.7.tgz",
+      "integrity": "sha512-g1Aznml3HmqTLSXylZhGwdfnAa67+vlNAYhT9ROJZkAxY7yYmWusND10olvCMPe4sVhZyVwn5tPkRzOg85kBEg=="
     },
     "node_modules/browserslist": {
       "version": "4.22.1",
@@ -3259,7 +3444,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
@@ -3322,22 +3508,18 @@
       }
     },
     "node_modules/dag-jose": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-4.0.0.tgz",
-      "integrity": "sha512-tw595L3UYoOUT9dSJPbBEG/qpRpw24kRZxa5SLRnlnr+g5L7O8oEs1d3W5TiVA1oJZbthVsf0Vi3zFN66qcEBA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-5.1.1.tgz",
+      "integrity": "sha512-9alfZ8Wh1XOOMel8bMpDqWsDT72ojFQCJPtwZSev9qh4f8GoCV9qrJW8jcOUhcstO8Kfm09FHGo//jqiZq3z9w==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.0",
-        "multiformats": "^11.0.0"
+        "multiformats": "~13.1.3"
       }
     },
     "node_modules/dag-jose/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.3.tgz",
+      "integrity": "sha512-CZPi9lFZCM/+7oRolWYsvalsyWQGFo+GpdaTmjxXXomC+nP/W1Rnxb9sUgjvmNmRZ5bOPqRAl4nuK+Ydw/4tGw=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3472,12 +3654,27 @@
       }
     },
     "node_modules/dns-over-http-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-3.0.0.tgz",
-      "integrity": "sha512-5+BI+B7n8LKhNaEZBYErr+CBd9t5nYtjunByLhrLGtZ+i3TRgiU8yE87pCjEBu2KOwNsD9ljpSXEbZ4S8xih5g==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
+      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+      "dev": true,
       "dependencies": {
-        "debug": "^4.3.4",
-        "receptacle": "^1.3.2"
+        "debug": "^4.3.1",
+        "native-fetch": "^4.0.2",
+        "receptacle": "^1.3.2",
+        "undici": "^5.12.0"
+      }
+    },
+    "node_modules/dns-over-http-resolver/node_modules/undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/dns-packet": {
@@ -4197,6 +4394,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
       "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4534,9 +4736,9 @@
       }
     },
     "node_modules/get-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-2.0.1.tgz",
-      "integrity": "sha512-7HuY/hebu4gryTDT7O/XY/fvY9wRByEGdK6QOa4of8npTcv0+NS6frFKABcf6S9EBAsveTuKTsZQQBFMMNILIg=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
@@ -4769,6 +4971,11 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/hash-test-vectors/-/hash-test-vectors-1.3.2.tgz",
       "integrity": "sha512-PKd/fitmsrlWGh3OpKbgNLE04ZQZsvs1ZkuLoQpeIKuwx+6CYVNdW6LaPIS1QAdZvV40+skk0w4YomKnViUnvQ=="
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
     "node_modules/hasown": {
       "version": "2.0.0",
@@ -5104,19 +5311,31 @@
       }
     },
     "node_modules/interface-datastore": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.5.tgz",
-      "integrity": "sha512-kvLGJMz3RPoJF/g5DbEvfWWempIiSBLVMf63b0PBsziVcSkj0ofzHYI86v8vqpGedkQ81DtPCUKyvX9W7zWvrQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.3.0.tgz",
+      "integrity": "sha512-RM/rTSmRcnoCwGZIHrPm+nlGYVoT4R0lcFvNnDyhdFT4R6BuHHhfFP47UldVEjs98SfxLuMhaNMsyjI918saHw==",
       "dependencies": {
-        "interface-store": "^5.0.0",
-        "nanoid": "^4.0.0",
-        "uint8arrays": "^4.0.2"
+        "interface-store": "6.0.0",
+        "uint8arrays": "^5.0.2"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/multiformats": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/interface-store": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.4.tgz",
-      "integrity": "sha512-SI2co5IAxAybBc9egRM2bXvHOa1RPh5SQQkO6di6t/aX92RbtzP4t8raB0l3GTzQmJADaBbzz8Tfa1QLgfMdGQ=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.0.tgz",
+      "integrity": "sha512-HkjsDPsjA7SKkCr+TH1elUQApAAM3X3JPwrz3vFzaf614wI+ZD6GVvwKGZCHYcbSRqeZP/uzVPqezzeISeo5kA=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.6",
@@ -5137,6 +5356,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.14.1.tgz",
       "integrity": "sha512-4ujF8NlM9bYi2I6AIqPP9wfGGX0x/gRCkMoFdOQfxxrFg6HcAdfS+0/irK8mp4e7znOHWReOHeWqCGw+dAPwsw==",
       "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dev": true,
       "dependencies": {
         "@ipld/dag-pb": "^4.0.0",
         "@libp2p/interface-keychain": "^2.0.0",
@@ -5158,6 +5378,7 @@
       "version": "11.6.1",
       "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
       "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dev": true,
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "dns-over-http-resolver": "^2.1.0",
@@ -5172,28 +5393,19 @@
       }
     },
     "node_modules/ipfs-core-types/node_modules/@types/node": {
-      "version": "18.18.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",
-      "integrity": "sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==",
+      "version": "18.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.43.tgz",
+      "integrity": "sha512-Mw/YlgXnyJdEwLoFv2dpuJaDFriX+Pc+0qOBJ57jC1H6cDxIj2xc5yUrdtArDVG0m+KV6622a4p2tenEqB3C/g==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/ipfs-core-types/node_modules/dns-over-http-resolver": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
-      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2",
-        "undici": "^5.12.0"
       }
     },
     "node_modules/ipfs-core-types/node_modules/interface-datastore": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
       "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
+      "dev": true,
       "dependencies": {
         "interface-store": "^3.0.0",
         "nanoid": "^4.0.0",
@@ -5208,6 +5420,21 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
       "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-types/node_modules/ipfs-unixfs": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-9.0.1.tgz",
+      "integrity": "sha512-jh2CbXyxID+v3jLml9CqMwjdSS9ZRnsGfQGGPOfem0/hT/L48xUeTPvh7qLFWkZcIMhZtG+fnS1teei8x5uGBg==",
+      "dev": true,
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "protobufjs": "^7.0.0"
+      },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -5217,17 +5444,28 @@
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
       "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/ipfs-core-types/node_modules/native-fetch": {
+    "node_modules/ipfs-core-types/node_modules/nanoid": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/ipfs-core-utils": {
@@ -5235,6 +5473,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.18.1.tgz",
       "integrity": "sha512-P7jTpdfvlyBG3JR4o+Th3QJADlmXmwMxbkjszXry6VAjfSfLIIqXsdeYPoVRkV69GFEeQozuz2k/jR+U8cUH/Q==",
       "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dev": true,
       "dependencies": {
         "@libp2p/logger": "^2.0.5",
         "@multiformats/multiaddr": "^11.1.5",
@@ -5262,10 +5501,64 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/ipfs-core-utils/node_modules/@libp2p/logger": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.1.1.tgz",
+      "integrity": "sha512-2UbzDPctg3cPupF6jrv6abQnAUTrbLybNOj0rmmrdGm1cN2HJ1o/hBu0sXuq4KF9P1h/eVRn1HIRbVIEKnEJrA==",
+      "dev": true,
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.2",
+        "@multiformats/multiaddr": "^12.1.3",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/@libp2p/logger/node_modules/@multiformats/multiaddr": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.3.0.tgz",
+      "integrity": "sha512-JQ8Gc/jgucqqvEaDTFN/AvxlYDHEE7lgEWLMYW7hKZkWggER+GvG/tVxUgUxIP8M0vFpvEHKKHE0lKzyMsgi8Q==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^1.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/@libp2p/logger/node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A==",
+      "dev": true
+    },
+    "node_modules/ipfs-core-utils/node_modules/@libp2p/logger/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/@libp2p/logger/node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A==",
+      "dev": true
+    },
     "node_modules/ipfs-core-utils/node_modules/@multiformats/multiaddr": {
       "version": "11.6.1",
       "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
       "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dev": true,
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "dns-over-http-resolver": "^2.1.0",
@@ -5279,38 +5572,56 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/ipfs-core-utils/node_modules/dns-over-http-resolver": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
-      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
+    "node_modules/ipfs-core-utils/node_modules/@multiformats/multiaddr-to-uri": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-9.0.8.tgz",
+      "integrity": "sha512-4eiN5iEiQfy2A98BxekUfW410L/ivg0sgjYSgSqmklnrBhK+QyMz4yqgfkub8xDTXOc7O5jp4+LVyM3ZqMeWNw==",
+      "dev": true,
       "dependencies": {
-        "debug": "^4.3.1",
-        "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2",
-        "undici": "^5.12.0"
+        "@multiformats/multiaddr": "^12.0.0"
       }
     },
-    "node_modules/ipfs-core-utils/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+    "node_modules/ipfs-core-utils/node_modules/@multiformats/multiaddr-to-uri/node_modules/@multiformats/multiaddr": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.3.0.tgz",
+      "integrity": "sha512-JQ8Gc/jgucqqvEaDTFN/AvxlYDHEE7lgEWLMYW7hKZkWggER+GvG/tVxUgUxIP8M0vFpvEHKKHE0lKzyMsgi8Q==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^1.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
       }
     },
-    "node_modules/ipfs-core-utils/node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
+    "node_modules/ipfs-core-utils/node_modules/@multiformats/multiaddr-to-uri/node_modules/multiformats": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A==",
+      "dev": true
+    },
+    "node_modules/ipfs-core-utils/node_modules/@multiformats/multiaddr-to-uri/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
-    "node_modules/ipfs-unixfs": {
+    "node_modules/ipfs-core-utils/node_modules/any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==",
+      "dev": true
+    },
+    "node_modules/ipfs-core-utils/node_modules/ipfs-unixfs": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-9.0.1.tgz",
       "integrity": "sha512-jh2CbXyxID+v3jLml9CqMwjdSS9ZRnsGfQGGPOfem0/hT/L48xUeTPvh7qLFWkZcIMhZtG+fnS1teei8x5uGBg==",
+      "dev": true,
       "dependencies": {
         "err-code": "^3.0.1",
         "protobufjs": "^7.0.0"
@@ -5320,10 +5631,79 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/ipfs-core-utils/node_modules/it-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/it-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
+      "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/it-peekable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-2.0.1.tgz",
+      "integrity": "sha512-fJ/YTU9rHRhGJOM2hhQKKEfRM6uKB9r4yGGFLBHqp72ACC8Yi6+7/FhuBAMG8cpN6mLoj9auVX7ZJ3ul6qFpTA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-core-utils/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/ipfs-unixfs": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.1.4.tgz",
+      "integrity": "sha512-RE4nyx5qgG2w7JOLj0Y0D7SfAR1ZkEdramNaBx0OSD4DlQ2Y2NORgc4FHfej3Pgy31v+QISDVP1pQJhdv3bUUg==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
     "node_modules/ipfs-utils": {
       "version": "9.0.14",
       "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.14.tgz",
       "integrity": "sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==",
+      "dev": true,
       "dependencies": {
         "any-signal": "^3.0.0",
         "browser-readablestream-to-it": "^1.0.0",
@@ -5347,20 +5727,39 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/ipfs-utils/node_modules/any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==",
+      "dev": true
+    },
     "node_modules/ipfs-utils/node_modules/browser-readablestream-to-it": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.3.tgz",
-      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="
+      "integrity": "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==",
+      "dev": true
     },
     "node_modules/ipfs-utils/node_modules/it-all": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
+      "dev": true
+    },
+    "node_modules/ipfs-utils/node_modules/it-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
     },
     "node_modules/ipfs-utils/node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5372,6 +5771,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/ipfs-utils/node_modules/native-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "dev": true,
+      "peerDependencies": {
+        "node-fetch": "*"
+      }
+    },
+    "node_modules/ipfs-utils/node_modules/stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+      "dev": true,
+      "dependencies": {
+        "get-iterator": "^1.0.2"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5776,69 +6193,69 @@
       }
     },
     "node_modules/it-all": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
-      "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.6.tgz",
+      "integrity": "sha512-HXZWbxCgQZJfrv5rXvaVeaayXED8nTKx9tj9fpBhmcUJcedVZshMMMqTj0RG2+scGypb9Ut1zd1ifbf3lA8L+Q=="
     },
     "node_modules/it-first": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
-      "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.6.tgz",
+      "integrity": "sha512-ExIewyK9kXKNAplg2GMeWfgjUcfC1FnUXz/RPfAvIXby+w7U4b3//5Lic0NV03gXT8O/isj5Nmp6KiY0d45pIQ=="
     },
     "node_modules/it-glob": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
-      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-2.0.7.tgz",
+      "integrity": "sha512-FjL2rAsGu566sMVKexFG5ciDoKoi1lgwXlSE6DW0yVbGRyvrlzi0OQ3fbfrw89dpIAzJFHnLNQwZS4yRkt3d/Q==",
       "dependencies": {
-        "@types/minimatch": "^3.0.4",
-        "minimatch": "^3.0.4"
+        "minimatch": "^9.0.4"
+      }
+    },
+    "node_modules/it-glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/it-glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/it-last": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.1.tgz",
-      "integrity": "sha512-uVMedYW0wa2Cx0TAmcOCLbfuLLII7+vyURmhKa8Zovpd+aBTMsmINtsta2n364wJ5qsEDBH+akY1sUtAkaYBlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.6.tgz",
+      "integrity": "sha512-M4/get95O85u2vWvWQinF8SJUc/RPC5bWTveBTYXvlP2q5TF9Y+QhT3nz+CRCyS2YEc66VJkyl/da6WrJ0wKhw=="
     },
     "node_modules/it-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.1.tgz",
-      "integrity": "sha512-a2GcYDHiAh/eSU628xlvB56LA98luXZnniH2GlD0IdBzf15shEq9rBeb0Rg3o1SWtNILUAwqmQxEXcewGCdvmQ==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.1.1.tgz",
+      "integrity": "sha512-9bCSwKD1yN1wCOgJ9UOl+46NQtdatosPWzxxUk2NdTLwRPXLh+L7iwCC9QKsbgM60RQxT/nH8bKMqm3H/o8IHQ==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
       }
     },
     "node_modules/it-peekable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-2.0.1.tgz",
-      "integrity": "sha512-fJ/YTU9rHRhGJOM2hhQKKEfRM6uKB9r4yGGFLBHqp72ACC8Yi6+7/FhuBAMG8cpN6mLoj9auVX7ZJ3ul6qFpTA==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.5.tgz",
+      "integrity": "sha512-JWQOGMt6rKiPcY30zUVMR4g6YxkpueTwHVE7CMs/aGqCf4OydM6w+7ZM3PvmO1e0TocjuR4aL8xyZWR46cTqCQ=="
     },
     "node_modules/it-pushable": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.1.tgz",
-      "integrity": "sha512-sLFz2Q0oyDCJpTciZog7ipP4vSftfPy3e6JnH6YyztRa1XqkpGQaafK3Jw/JlfEBtCXfnX9uVfcpu3xpSAqCVQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.3.tgz",
+      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
       "dependencies": {
         "p-defer": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/it-stream-types": {
@@ -5862,11 +6279,6 @@
         "p-fifo": "^1.0.0",
         "readable-stream": "^3.6.0"
       }
-    },
-    "node_modules/it-to-stream/node_modules/get-iterator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
-      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "node_modules/it-to-stream/node_modules/p-defer": {
       "version": "3.0.0",
@@ -6557,78 +6969,55 @@
       }
     },
     "node_modules/kubo-rpc-client": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/kubo-rpc-client/-/kubo-rpc-client-3.0.1.tgz",
-      "integrity": "sha512-2SMH/eCZlwR/4e9Aqr0HC1gJvCDTsgBRWRdu4LjHLrRwGsmDAl32vK4PkwkKfYwgJMHY3lgA6eZzaOLzrPwxFg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/kubo-rpc-client/-/kubo-rpc-client-4.1.1.tgz",
+      "integrity": "sha512-vxIkTQLvDqd2DEcBfz7DWegAidYtopmWUR/UhWyuuss9+JNFzV5neBn8BKxSDHoLJPvkxJpqXDaJhsb7ZuPouQ==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.0",
         "@ipld/dag-pb": "^4.0.0",
-        "@libp2p/crypto": "^1.0.11",
-        "@libp2p/logger": "^2.0.5",
-        "@libp2p/peer-id": "^2.0.0",
-        "@multiformats/multiaddr": "^11.1.5",
-        "any-signal": "^3.0.1",
-        "dag-jose": "^4.0.0",
+        "@libp2p/interface": "^1.2.0",
+        "@libp2p/logger": "^4.0.10",
+        "@libp2p/peer-id": "^4.0.10",
+        "@multiformats/multiaddr": "^12.2.1",
+        "@multiformats/multiaddr-to-uri": "^10.0.1",
+        "any-signal": "^4.1.1",
+        "blob-to-it": "^2.0.5",
+        "browser-readablestream-to-it": "^2.0.5",
+        "dag-jose": "^5.0.0",
+        "electron-fetch": "^1.9.1",
         "err-code": "^3.0.1",
-        "ipfs-core-utils": "^0.18.0",
-        "ipfs-utils": "^9.0.7",
-        "it-first": "^2.0.0",
-        "it-last": "^2.0.0",
+        "ipfs-unixfs": "^11.1.4",
+        "iso-url": "^1.2.1",
+        "it-all": "^3.0.4",
+        "it-first": "^3.0.4",
+        "it-glob": "^2.0.6",
+        "it-last": "^3.0.4",
+        "it-map": "^3.0.5",
+        "it-peekable": "^3.0.3",
+        "it-to-stream": "^1.0.0",
         "merge-options": "^3.0.4",
-        "multiformats": "^11.0.0",
-        "parse-duration": "^1.0.2",
-        "stream-to-it": "^0.2.4",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/kubo-rpc-client/node_modules/@multiformats/multiaddr": {
-      "version": "11.6.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
-      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "multiformats": "^11.0.0",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/kubo-rpc-client/node_modules/dns-over-http-resolver": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-2.1.3.tgz",
-      "integrity": "sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==",
-      "dependencies": {
-        "debug": "^4.3.1",
+        "multiformats": "^13.1.0",
+        "nanoid": "^5.0.7",
         "native-fetch": "^4.0.2",
-        "receptacle": "^1.3.2",
-        "undici": "^5.12.0"
+        "parse-duration": "^1.0.2",
+        "react-native-fetch-api": "^3.0.0",
+        "stream-to-it": "^1.0.1",
+        "uint8arrays": "^5.0.3",
+        "wherearewe": "^2.0.1"
       }
     },
     "node_modules/kubo-rpc-client/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
     },
-    "node_modules/kubo-rpc-client/node_modules/native-fetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
-      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
-      "peerDependencies": {
-        "undici": "*"
+    "node_modules/kubo-rpc-client/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/leven": {
@@ -6722,7 +7111,8 @@
     "node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "dev": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -6814,6 +7204,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6852,9 +7243,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
+      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
       "funding": [
         {
           "type": "github",
@@ -6865,15 +7256,15 @@
         "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/native-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
-      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-4.0.2.tgz",
+      "integrity": "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==",
       "peerDependencies": {
-        "node-fetch": "*"
+        "undici": "*"
       }
     },
     "node_modules/natural-compare": {
@@ -7195,9 +7586,9 @@
       }
     },
     "node_modules/p-defer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
-      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
       "engines": {
         "node": ">=12"
       },
@@ -7247,6 +7638,32 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
+      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7501,6 +7918,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/progress-events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.1.tgz",
+      "integrity": "sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw=="
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -7520,9 +7942,10 @@
       "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -7543,12 +7966,26 @@
       }
     },
     "node_modules/protons-runtime": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.2.0.tgz",
-      "integrity": "sha512-jL3VSbXllgm17zurKQ/z+Ath0w+4BknJ+l/NLocfjAB8hbeASOZTNtb7zK3nDsKq2pHK9YFumNQvpkZ6gFfWhA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.5.0.tgz",
+      "integrity": "sha512-EsALjF9QsrEk6gbCx3lmfHxVN0ah7nG3cY7GySD4xf4g8cr7g543zB88Foh897Sr1RQJ9yDCUsoT1i1H/cVUFA==",
       "dependencies": {
+        "uint8-varint": "^2.0.2",
         "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^4.0.6"
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/multiformats": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
+    },
+    "node_modules/protons-runtime/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/punycode": {
@@ -7612,11 +8049,6 @@
         }
       ]
     },
-    "node_modules/race-signal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.0.1.tgz",
-      "integrity": "sha512-a5un4dInIWoB7+76DieVE+Xv+wmyochKJ3P2GVs9dUKIzGuPyFR5iU3gEWJvztde/15fSOGkslbIsPxi+Loosw=="
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -7679,6 +8111,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
       "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -7800,7 +8233,8 @@
     "node_modules/retimer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
-      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==",
+      "dev": true
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -8114,17 +8548,12 @@
       }
     },
     "node_modules/stream-to-it": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
-      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-1.0.1.tgz",
+      "integrity": "sha512-AqHYAYPHcmvMrcLNgncE/q0Aj/ajP6A4qGhxP6EVn7K3YTNs0bJpJyk57wc2Heb7MUL64jurvmnmui8D9kjZgA==",
       "dependencies": {
-        "get-iterator": "^1.0.2"
+        "it-stream-types": "^2.0.1"
       }
-    },
-    "node_modules/stream-to-it/node_modules/get-iterator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
-      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -8293,6 +8722,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
       "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
+      "dev": true,
       "dependencies": {
         "retimer": "^3.0.0"
       }
@@ -8542,15 +8972,24 @@
       }
     },
     "node_modules/uint8arraylist": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
-      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.8.tgz",
+      "integrity": "sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==",
       "dependencies": {
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/multiformats": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.2.2.tgz",
+      "integrity": "sha512-RWI+nyf0q64vyOxL8LbKtjJMki0sogRL/8axvklNtiTM0iFCVtHwME9w6+0P1/v4dQvsIg8A45oT3ka1t/M/+A=="
+    },
+    "node_modules/uint8arraylist/node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/uint8arrays": {
@@ -8577,14 +9016,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
-      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "6.19.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.5.tgz",
+      "integrity": "sha512-LryC15SWzqQsREHIOUybavaIHF5IoL0dJ9aWWxL/PgT1KfqAW5225FZpDUFlt9xiDMS2/S7DOKhFWA7RLksWdg==",
+      "peer": true,
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -8670,7 +9107,8 @@
     "node_modules/varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "dev": true
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -8689,6 +9127,34 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/weald": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.0.2.tgz",
+      "integrity": "sha512-iG5cIuBwsPe1ZcoGGd4X6QYlepU1vLr4l4oWpzQWqeJPSo9B8bxxyE6xlnj3TCmThtha7gyVL+uuZgUFkPyfDg==",
+      "dependencies": {
+        "ms": "^3.0.0-canary.1",
+        "supports-color": "^9.4.0"
+      }
+    },
+    "node_modules/weald/node_modules/ms": {
+      "version": "3.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
+      "engines": {
+        "node": ">=12.13"
+      }
+    },
+    "node_modules/weald/node_modules/supports-color": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -8701,6 +9167,18 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wherearewe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
+      "dependencies": {
+        "is-electron": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ethers": "^6.13.2",
     "graphql-request": "^6.1.0",
     "iexec": "^8.10.0",
-    "kubo-rpc-client": "^3.0.1",
+    "kubo-rpc-client": "^4.1.1",
     "yup": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Why?

PR on kubo's side: https://github.com/ipfs/js-kubo-rpc-client/pull/221

Especially:

> Remove legacy ipfs-core-types and ipfs-utils dependencies

Which does some magic trying to find the correct `fetch` implementation, which seems to break usage of our SDK in Next.js SSR.

---

Same PR for `dataprotector-sdk`: https://github.com/iExecBlockchainComputing/dataprotector-sdk/pull/341