### PR TITLE
Don't throw if bad email

### DIFF
--- a/dapp/src/validateEmailAddress.js
+++ b/dapp/src/validateEmailAddress.js
@@ -1,6 +1,17 @@
 // fetch is not included in node 14
 const fetch = require('node-fetch');
 
+/**
+ * Mailgun answer should look like this:
+ *   {
+ *     "address": "foo@mailgun.net",
+ *     "is_disposable_address": false,
+ *     "is_role_address": false,
+ *     "reason": [],
+ *     "result": "deliverable",
+ *     "risk": "low"
+ *   }
+ */
 async function validateEmailAddress({ emailAddress, mailgunApiKey }) {
   // https://documentation.mailgun.com/docs/inboxready/mailgun-validate/single-valid-ir/#single-validation
   const basicAuth = Buffer.from(`api:${mailgunApiKey}`).toString('base64');
@@ -18,14 +29,24 @@ async function validateEmailAddress({ emailAddress, mailgunApiKey }) {
 
   if (!response.ok) {
     // Mailgun API down? Prefer not to throw
-    return;
+    console.warn("Oops, can't reach mailgun validation API");
+    const notOkResponse = await response.json();
+    console.warn(notOkResponse);
+    return { isEmailAddressValid: null };
   }
 
   const emailAddressSeemsLegit = await response.json();
 
   if (emailAddressSeemsLegit.result !== 'deliverable') {
-    throw new Error('The protected email address seems to be invalid.');
+    console.error('The protected email address seems to be invalid.', {
+      ...emailAddressSeemsLegit,
+      // Don't log email address
+      address: undefined,
+    });
+    return { isEmailAddressValid: false, result: emailAddressSeemsLegit };
   }
+
+  return { isEmailAddressValid: true };
 }
 
 module.exports = {


### PR DESCRIPTION
Since the last version of web3mail dapp, we abort the iExec task of sending an email if the email address does not seem legit.
👉 That is not completely appropriate in terms of what a failed iExec task represents. (It has further consequences, it could be claimed, etc.)

In this PR, no more error throwing, the task will still be successful, but no email would be sent and `result.txt` would include a message:
```
The protected email address seems to be invalid. See task logs for more information.
```
plus some other deliverability info.