### PR TITLE
Feature/dapp/add check email previous check and add callbackresult

### DIFF
--- a/dapp/package-lock.json
+++ b/dapp/package-lock.json
@@ -1101,6 +1101,11 @@
       "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
       "dev": true
     },
+    "@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="
+    },
     "@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -3519,7 +3524,6 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
       "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-      "dev": true,
       "requires": {
         "node-fetch": "^2.6.12"
       }
@@ -5090,6 +5094,15 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "graphql-request": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.0.0.tgz",
+      "integrity": "sha512-2BmHTuglonjZvmNVw6ZzCfFlW/qkIPds0f+Qdi/Lvjsl3whJg2uvHmSvHnLWhUTEw6zcxPYAHiZoPvSVKOZ7Jw==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "cross-fetch": "^3.1.5"
+      }
     },
     "har-schema": {
       "version": "2.0.0",

--- a/dapp/package.json
+++ b/dapp/package.json
@@ -21,6 +21,7 @@
   "license": "ISC",
   "dependencies": {
     "@iexec/dataprotector-deserializer": "^0.1.0",
+    "graphql-request": "^6.0.0",
     "joi": "^17.9.2",
     "jszip": "^3.10.1",
     "node-fetch": "^2.7.0",

--- a/dapp/src/checkEmailPreviousValidation.js
+++ b/dapp/src/checkEmailPreviousValidation.js
@@ -1,0 +1,51 @@
+const { request, gql } = require('graphql-request');
+
+async function checkEmailPreviousValidation({ datasetAddress, dappAddresses }) {
+  const pocoSubgraphUrl =
+    'https://thegraph.bellecour.iex.ec/subgraphs/name/bellecour/poco-v5';
+
+  const query = gql`
+    query checkSuccessfulTaskQuery($apps: [String!], $dataset: String!) {
+      tasks(
+        where: {
+          resultsCallback_not: "0x"
+          status: "COMPLETED"
+          deal_: { dataset: $dataset, app_in: $apps }
+        }
+      ) {
+        resultsCallback
+      }
+    }
+  `;
+
+  const variables = {
+    apps: dappAddresses,
+    dataset: datasetAddress.toLowerCase(),
+  };
+
+  try {
+    const data = await request(pocoSubgraphUrl, query, variables);
+    const tasks = data?.tasks || [];
+
+    return tasks.some((task) => {
+      const callback = task.resultsCallback?.toLowerCase();
+      return (
+        callback &&
+        callback.startsWith('0x') &&
+        callback.endsWith(
+          '0000000000000000000000000000000000000000000000000000000000000001'
+        )
+      );
+    });
+  } catch (error) {
+    console.error(
+      'GraphQL error:',
+      error.response?.errors || error.message || error
+    );
+    return false;
+  }
+}
+
+module.exports = {
+  checkEmailPreviousValidation,
+};

--- a/dapp/tests/unit/checkEmailPreviousValidation.test.js
+++ b/dapp/tests/unit/checkEmailPreviousValidation.test.js
@@ -1,0 +1,76 @@
+const { request } = require('graphql-request');
+const {
+  checkEmailPreviousValidation,
+} = require('../../src/checkEmailPreviousValidation');
+
+jest.mock('graphql-request', () => ({
+  gql: jest.fn((literals) => literals.join('')), // pass-through for query template
+  request: jest.fn(),
+}));
+
+describe('checkEmailPreviousValidation', () => {
+  const datasetAddress = '0x9585b5427503e69d61b9db2adbc14e0853075ef0';
+  const dappAddresses = ['0xa638bf4665ce7bd7021a4a12416ea7a0a3272b6f'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true if a valid email verification callback exists', async () => {
+    request.mockResolvedValue({
+      tasks: [
+        {
+          resultsCallback:
+            '0x0000000000000000000000000000000000000000000000000000000000000001',
+        },
+      ],
+    });
+
+    const result = await checkEmailPreviousValidation({
+      datasetAddress,
+      dappAddresses,
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns false if no tasks are returned', async () => {
+    request.mockResolvedValue({ tasks: [] });
+
+    const result = await checkEmailPreviousValidation({
+      datasetAddress,
+      dappAddresses,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns false if none of the callbacks indicate a valid verification', async () => {
+    request.mockResolvedValue({
+      tasks: [
+        {
+          resultsCallback:
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+        },
+        {
+          resultsCallback:
+            '0xabcdef1234567890abcdef000000000000000000000000000000000000000000',
+        },
+      ],
+    });
+
+    const result = await checkEmailPreviousValidation({
+      datasetAddress,
+      dappAddresses,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns false if GraphQL query fails', async () => {
+    request.mockRejectedValue(new Error('GraphQL request failed'));
+
+    const result = await checkEmailPreviousValidation({
+      datasetAddress,
+      dappAddresses,
+    });
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
- Introduced a check against the PoCo subgraph to detect if an email has already been verified in a previous iExec task.

- If a valid verification callback is found (0x…01), the Mailgun validation step is skipped — saving cost and time.

- If not found, Mailgun is called, and the result is encoded as a 32-byte ABI-style boolean and pushed as a callback-data in computed.json.

this needs further deployed testing with the new dapp developer secret