### PR TITLE
ci: move WEB3MAIL_WHITELIST_CONTRACT_ADDRESS from env secrets to vars

### DIFF
--- a/.github/workflows/dapp-deploy.yml
+++ b/.github/workflows/dapp-deploy.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Add resource to whitelist
         env:
-          CONTRACT_ADDRESS: ${{ secrets.WEB3MAIL_WHITELIST_CONTRACT_ADDRESS }}
+          CONTRACT_ADDRESS: ${{ vars.WEB3MAIL_WHITELIST_CONTRACT_ADDRESS }}
           WALLET_PRIVATE_KEY: ${{ secrets.WEB3MAIL_APP_OWNER_PRIVATEKEY }}
         run: |
           cd node_modules/whitelist-smart-contract

--- a/.github/workflows/dapp-release.yml
+++ b/.github/workflows/dapp-release.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Add resource to whitelist
         env:
-          CONTRACT_ADDRESS: ${{ secrets.WEB3MAIL_WHITELIST_CONTRACT_ADDRESS }}
+          CONTRACT_ADDRESS: ${{ vars.WEB3MAIL_WHITELIST_CONTRACT_ADDRESS }}
           WALLET_PRIVATE_KEY: ${{ secrets.WEB3MAIL_APP_OWNER_PRIVATEKEY }}
         run: |
           cd node_modules/whitelist-smart-contract


### PR DESCRIPTION
:warning: make sure all environments have `WEB3MAIL_WHITELIST_CONTRACT_ADDRESS` var set

- [x] [bellecour-dev](https://github.com/iExecBlockchainComputing/web3mail-sdk/settings/environments/7655121864/edit)
- [x] [bellecour-prod](https://github.com/iExecBlockchainComputing/web3mail-sdk/settings/environments/7630028653/edit)
- [x] [arbitrum-sepolia-dev](https://github.com/iExecBlockchainComputing/web3mail-sdk/settings/environments/7671494667/edit)
- [x] [arbitrum-sepolia-prod](https://github.com/iExecBlockchainComputing/web3mail-sdk/settings/environments/7718849666/edit)