### PR TITLE
chore(deps): upgrade iexec to 8.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "buffer": "^6.0.3",
         "ethers": "^6.15.0",
         "graphql-request": "^6.1.0",
-        "iexec": "^8.23.0",
+        "iexec": "^8.24.0",
         "kubo-rpc-client": "^5.4.1",
         "yup": "^1.1.1"
       },
@@ -5543,9 +5543,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/iexec": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.23.0.tgz",
-      "integrity": "sha512-59NtZBChueZfSEFr2L4X+Pi4Be2c92hAxkgsYDqhMgbPXFKNxLB63ZrWF/kvnZqwX4LZbgXtbNBRvxHcMEZjNQ==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.24.0.tgz",
+      "integrity": "sha512-XMi+kZlRHPB5prubA7PQvhEmKxENN/5P0+gfe96eKKUWZSb3qllzi14btRE/MEmUXwsQok9kpIOq9IajUY8VQQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@multiformats/multiaddr": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "buffer": "^6.0.3",
     "ethers": "^6.15.0",
     "graphql-request": "^6.1.0",
-    "iexec": "^8.23.0",
+    "iexec": "^8.24.0",
     "kubo-rpc-client": "^5.4.1",
     "yup": "^1.1.1"
   },


### PR DESCRIPTION
## Summary
Upgrade the `iexec` dependency from `8.23.0` to `8.24.0`.

## Motivation
Previous versions of the iexec SDK do not support the TDX SMS on Arbitrum One.
This upgrade is required to ensure compatibility with the new Arbitrum One deployment.

## Changes
- Bump `iexec` from `^8.23.0` to `^8.24.0` in `package.json`
